### PR TITLE
Follow token discovery WLCG standard

### DIFF
--- a/ferry.py
+++ b/ferry.py
@@ -18,7 +18,7 @@ def get_default_paths(config: TConfig) -> Tuple[str, str]:
 
 
 def set_auth_from_args(
-    auth_method: str, token_path: str, cert_path: str, ca_path: str
+    auth_method: str, token_path: Optional[str], cert_path: str, ca_path: str
 ) -> Auth:
     """Set the auth class based on the given arguments"""
     if auth_method == "token":
@@ -69,7 +69,6 @@ class FerryCLI:
         )
         auth_group.add_argument(
             "--token-path",
-            default=get_default_token_path(),
             help="Path to bearer token",
         )
 

--- a/helpers/auth.py
+++ b/helpers/auth.py
@@ -41,7 +41,6 @@ def default_token_file_name() -> str:
     return f"bt_u{uid}"
 
 
-# TODO Test this by passing in "blahblah\n" into a temp file, read it, make sure we get the right result
 # Thanks to https://github.com/fermitools/jobsub_lite/blob/master/lib/tarfiles.py for this tidbit
 def read_in_token(token_path: str) -> str:
     """Read the contents of a token file from a given token path"""

--- a/helpers/auth.py
+++ b/helpers/auth.py
@@ -10,7 +10,7 @@ import requests.auth
 __all__ = [
     "Auth",
     "DEFAULT_CA_DIR",
-    "get_default_token_path",
+    "get_default_token_string",
     "get_default_cert_path",
     "AuthToken",
     "AuthCert",

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,6 +26,11 @@ def token_file_name(monkeypatch):
     return auth.default_token_file_name()
 
 
+@pytest.mark.unit
+def test_read_in_token(create_fake_credential):
+    assert auth.read_in_token(create_fake_credential) == FAKE_CREDENTIAL_DATA.strip()
+
+
 class TestGetDefaultTokenString:
     @pytest.mark.unit
     def test_get_default_token_string_bearer_token_val(self, monkeypatch):
@@ -36,6 +41,7 @@ class TestGetDefaultTokenString:
     def test_get_default_token_string_bearer_token_file(
         self, create_fake_credential, monkeypatch
     ):
+        monkeypatch.delenv("BEARER_TOKEN", raising=False)
         monkeypatch.setenv("BEARER_TOKEN_FILE", create_fake_credential)
         assert auth.get_default_token_string() == FAKE_CREDENTIAL_DATA.strip()
 
@@ -46,6 +52,8 @@ class TestGetDefaultTokenString:
         fake_credential = create_fake_credential
         fake_cred_dir = str(Path(fake_credential).parent)
         copyfile(fake_credential, f"{fake_cred_dir}/{token_file_name}")
+        monkeypatch.delenv("BEARER_TOKEN", raising=False)
+        monkeypatch.delenv("BEARER_TOKEN_FILE", raising=False)
         monkeypatch.setenv("XDG_RUNTIME_DIR", fake_cred_dir)
         assert auth.get_default_token_string() == FAKE_CREDENTIAL_DATA.strip()
 

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,4 +1,5 @@
 import os
+from shutil import copyfile
 from pathlib import Path
 
 import pytest
@@ -6,7 +7,7 @@ from requests import Session
 
 from helpers import auth
 
-FAKE_CREDENTIAL_DATA = "fakecredential"
+FAKE_CREDENTIAL_DATA = "fakecredential\n"
 
 
 @pytest.fixture
@@ -16,20 +17,56 @@ def create_fake_credential(tmp_path):
     d.mkdir()
     t = d / "fake_cred_file"
     t.write_text(FAKE_CREDENTIAL_DATA)
-    return t.absolute()
+    return str(t.absolute())  # Return the string since that's what we care about
 
 
-class TestGetDefaultTokenPath:
+@pytest.fixture
+def token_file_name(monkeypatch):
+    monkeypatch.setattr(auth, "geteuid", lambda: 42)
+    return auth.default_token_file_name()
+
+
+"""
+1.  BEARER_TOKEN value
+2. BEARER_TOKEN_FILE file
+3. XDG_RUNTIME_DIR/bt_u$(id -u) file
+4. /tmp/bt_u$(id -u)
+"""
+
+
+class TestGetDefaultTokenString:
     @pytest.mark.unit
-    def test_get_default_token_path_env(self, monkeypatch):
-        monkeypatch.setenv("BEARER_TOKEN_FILE", "randompathtotoken")
-        assert auth.get_default_token_path() == "randompathtotoken"
+    def test_get_default_token_string_bearer_token_val(self, monkeypatch):
+        monkeypatch.setenv("BEARER_TOKEN", "randomtokenstring")
+        assert auth.get_default_token_string() == "randomtokenstring"
 
     @pytest.mark.unit
-    def test_get_default_token_path(self, monkeypatch):
+    def test_get_default_token_string_bearer_token_file(
+        self, create_fake_credential, monkeypatch
+    ):
+        monkeypatch.setenv("BEARER_TOKEN_FILE", create_fake_credential)
+        assert auth.get_default_token_string() == FAKE_CREDENTIAL_DATA.strip()
+
+    @pytest.mark.unit
+    def test_get_default_token_string_xdg_runtime_dir(
+        self, create_fake_credential, token_file_name, monkeypatch
+    ):
+        fake_credential = create_fake_credential
+        fake_cred_dir = str(Path(fake_credential).parent)
+        copyfile(fake_credential, f"{fake_cred_dir}/{token_file_name}")
+        monkeypatch.setenv("XDG_RUNTIME_DIR", fake_cred_dir)
+        assert auth.get_default_token_string() == FAKE_CREDENTIAL_DATA.strip()
+
+    @pytest.mark.unit
+    def test_get_default_token_string_fallthrough(
+        self, create_fake_credential, token_file_name, monkeypatch
+    ):
+        monkeypatch.delenv("BEARER_TOKEN", raising=False)
         monkeypatch.delenv("BEARER_TOKEN_FILE", raising=False)
-        monkeypatch.setattr(auth, "geteuid", lambda: 42)
-        assert auth.get_default_token_path() == f"/run/user/42/bt_u42"
+        monkeypatch.delenv("XDG_RUNTIME_DIR", raising=False)
+        fake_credential = create_fake_credential
+        copyfile(fake_credential, f"/tmp/{token_file_name}")
+        assert auth.get_default_token_string() == FAKE_CREDENTIAL_DATA.strip()
 
 
 class TestGetDefaultCertPath:
@@ -51,7 +88,10 @@ class TestAuthToken:
         s = Session()
         authorizer = auth.AuthToken(create_fake_credential)
         auth_session = authorizer(s)
-        assert auth_session.headers["Authorization"] == f"Bearer {FAKE_CREDENTIAL_DATA}"
+        assert (
+            auth_session.headers["Authorization"]
+            == f"Bearer {FAKE_CREDENTIAL_DATA.strip()}"
+        )
 
     @pytest.mark.unit
     def test_AuthToken_bad(self):

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -26,14 +26,6 @@ def token_file_name(monkeypatch):
     return auth.default_token_file_name()
 
 
-"""
-1.  BEARER_TOKEN value
-2. BEARER_TOKEN_FILE file
-3. XDG_RUNTIME_DIR/bt_u$(id -u) file
-4. /tmp/bt_u$(id -u)
-"""
-
-
 class TestGetDefaultTokenString:
     @pytest.mark.unit
     def test_get_default_token_string_bearer_token_val(self, monkeypatch):


### PR DESCRIPTION
This addresses @DrDaveD 's point that token discovery should be fully implemented according to the [WLCG standard](https://zenodo.org/records/3937438) if we're being at all intelligent about token searching (which we are).  So now, we will follow the standard of checking the following in order:

1.  `$BEARER_TOKEN`
2. `$BEARER_TOKEN_FILE`
3. `$XDG_RUNTIME_DIR`
4. `/tmp/bt_u$(id -u)`

I also updated the unit tests, as well as testing by changing my environment around to make sure the full command works with the various choices above set properly.