### PR TITLE
For all the args that print help-type text, use callback functions

### DIFF
--- a/ferry.py
+++ b/ferry.py
@@ -105,6 +105,7 @@ class FerryCLI:
                 )
                 for subparser in endpoints.values():
                     print(subparser.description)
+                sys.exit(0)
 
         return _ListEndpoints
 
@@ -120,6 +121,7 @@ class FerryCLI:
                 )
                 for workflow in SUPPORTED_WORKFLOWS.values():
                     workflow().get_description()
+                sys.exit(0)
 
         return _ListWorkflows
 
@@ -134,6 +136,7 @@ class FerryCLI:
                 # Prevent DCS from running this endpoint if necessary, and print proper steps to take instead.
                 safeguards.verify(values)
                 ferrycli_get_endpoint_params(values)
+                sys.exit(0)
 
         return _GetEndpointParams
 
@@ -147,6 +150,7 @@ class FerryCLI:
                     workflow = SUPPORTED_WORKFLOWS[values]()
                     workflow.init_parser()
                     workflow.get_info()
+                    sys.exit(0)
                 except KeyError as e:
                     raise KeyError(f"Error: '{values}' is not a supported workflow.")
 

--- a/ferry.py
+++ b/ferry.py
@@ -1,8 +1,9 @@
+import argparse
 import json
 import os
 import sys
 import textwrap
-from typing import Any, Dict, Optional, List, Tuple, Type
+from typing import Any, Dict, Optional, List, Tuple
 
 from helpers.customs import TConfig, FerryParser
 from helpers.supported_workflows import SUPPORTED_WORKFLOWS
@@ -40,7 +41,7 @@ class FerryCLI:
         self.endpoints = self.generate_endpoints()
         self.safeguards = SafeguardsDCS()
         self.parser = self.get_arg_parser()
-        
+
     def get_arg_parser(self: "FerryCLI") -> FerryParser:
         parser = FerryParser.create(description="CLI for Ferry API endpoints")
         parser.add_argument(
@@ -60,57 +61,117 @@ class FerryCLI:
         parser.add_argument(
             "-le",
             "--list_endpoints",
-            action="store_true",
+            action=self.list_available_endpoints_action(),
+            nargs=0,
             help="List all available endpoints",
         )
         parser.add_argument(
-            '-lw', 
-            '--list_workflows', 
-            action='store_true', 
-            help="List all supported custom workflows"
+            "-lw",
+            "--list_workflows",
+            action=self.list_workflows_action(),  # type: ignore
+            nargs=0,
+            help="List all supported custom workflows",
         )
         parser.add_argument(
-            '-ep', 
-            '--endpoint_params', 
-            help="List parameters for the selected endpoint"
+            "-ep",
+            "--endpoint_params",
+            action=self.get_endpoint_params_action(),  # type: ignore
+            help="List parameters for the selected endpoint",
         )
         parser.add_argument(
-            '-wp', 
-            '--workflow_params', 
-            help="List parameters for the supported workflow"
+            "-wp",
+            "--workflow_params",
+            action=self.workflow_params_action(),  # type: ignore
+            help="List parameters for the supported workflow",
         )
+        parser.add_argument("-e", "--endpoint", help="API endpoint and parameters")
+        parser.add_argument("-w", "--workflow", help="Execute supported workflows")
         parser.add_argument(
-            '-e', '--endpoint', help="API endpoint and parameters"
-        )
-        parser.add_argument(
-            '-w', '--workflow', help="Execute supported workflows"
-            )
-        parser.add_argument(
-            '-q', '--quiet', action='store_true', default=False, help="Hide output"
+            "-q", "--quiet", action="store_true", default=False, help="Hide output"
         )
         return parser
-    
-    def list_available_endpoints(self: "FerryCLI") -> None:
-        print("""
-              Listing all available endpoints:
-              """)
-        for subparser in self.endpoints.values():
-            print(subparser.description)
-    
+
+    def list_available_endpoints_action(self: "FerryCLI"):  # type: ignore
+        endpoints = self.endpoints
+
+        class _ListEndpoints(argparse.Action):
+            def __call__(  # type: ignore
+                self: "_ListEndpoints", parser, args, values, option_string=None
+            ) -> None:
+                print(
+                    """
+                    Listing all available endpoints:
+                    """
+                )
+                for subparser in endpoints.values():
+                    print(subparser.description)
+
+        return _ListEndpoints
+
+    def list_workflows_action(self):  # type: ignore
+        class _ListWorkflows(argparse.Action):
+            def __call__(  # type: ignore
+                self: "_ListWorkflows", parser, args, values, option_string=None
+            ) -> None:
+                print(
+                    """
+                      Listing all supported workflows:
+                      """
+                )
+                for workflow in SUPPORTED_WORKFLOWS.values():
+                    workflow().get_description()
+
+        return _ListWorkflows
+
+    def get_endpoint_params_action(self):  # type: ignore
+        safeguards = self.safeguards
+        ferrycli_get_endpoint_params = self.get_endpoint_params
+
+        class _GetEndpointParams(argparse.Action):
+            def __call__(  # type: ignore
+                self: "_GetEndpointParams", parser, args, values, option_string=None
+            ) -> None:
+                # Prevent DCS from running this endpoint if necessary, and print proper steps to take instead.
+                safeguards.verify(values)
+                ferrycli_get_endpoint_params(values)
+
+        return _GetEndpointParams
+
+    def workflow_params_action(self):  # type: ignore
+        class _WorkflowParams(argparse.Action):
+            def __call__(  # type: ignore
+                self: "_WorkflowParams", parser, args, values, option_string=None
+            ) -> None:
+                try:
+                    # Finds workflow inherited class in dictionary if exists, and initializes it.
+                    workflow = SUPPORTED_WORKFLOWS[values]()
+                    workflow.init_parser()
+                    workflow.get_info()
+                except KeyError as e:
+                    raise KeyError(f"Error: '{values}' is not a supported workflow.")
+
+        return _WorkflowParams
+
     def get_endpoint_params(self: "FerryCLI", endpoint: str) -> None:
-        print("""
-              Listing parameters for endpoint: %s%s" 
-              """ % (self.base_url,endpoint))
+        print(
+            """
+              Listing parameters for endpoint: %s%s"
+              """
+            % (self.base_url, endpoint)
+        )
         subparser = self.endpoints.get(endpoint, None)
         if not subparser:
-            print("""
+            print(
+                """
                   Error: '%s' is not a valid endpoint. Run 'ferry -l' for a full list of available endpoints.
-                  """ % endpoint)
+                  """
+                % endpoint
+            )
         else:
             print(subparser.format_help())
             print()
 
-    def execute_endpoint(self: "FerryCLI", endpoint: str, params: List[str]) -> str:
+    def execute_endpoint(self: "FerryCLI", endpoint: str, params: List[str]) -> Any:
         try:
             subparser = self.endpoints[endpoint]
         except KeyError:
@@ -133,10 +194,14 @@ class FerryCLI:
                     method = "post"
                 elif "put" in data:
                     method = "put"
-                    
-                endpoint_parser = FerryParser.create_subparser(endpoint, method=method.upper(), description=data[method]["description"])
-                endpoint_parser.set_arguments(data[method].get("parameters", [])) 
-                endpoints[path.replace("/","")] = endpoint_parser
+
+                endpoint_parser = FerryParser.create_subparser(
+                    endpoint,
+                    method=method.upper(),
+                    description=data[method]["description"],
+                )
+                endpoint_parser.set_arguments(data[method].get("parameters", []))
+                endpoints[path.replace("/", "")] = endpoint_parser
         return endpoints
 
     def parse_description(
@@ -177,32 +242,14 @@ class FerryCLI:
                 workflow = SUPPORTED_WORKFLOWS[args.workflow]()
                 workflow.init_parser()
                 self.ferry_api = FerryAPI(
-                        base_url=self.base_url, authorizer=authorizer, quiet=args.quiet
-                    )
+                    base_url=self.base_url, authorizer=authorizer, quiet=args.quiet
+                )
                 workflow_params, _ = workflow.parser.parse_known_args(endpoint_args)
-                json_result = workflow.run(self.ferry_api, vars(workflow_params))
+                json_result = workflow.run(self.ferry_api, vars(workflow_params))  # type: ignore
                 if not args.quiet:
                     self.handle_output(json.dumps(json_result, indent=4))
             except KeyError as e:
-                    raise KeyError(f"Error: '{args.workflow}' is not a supported workflow.")
-        elif args.list_endpoints:
-            self.list_available_endpoints()
-        elif args.list_workflows:
-            print("\nListing all supported workflows: \n")
-            for workflow in SUPPORTED_WORKFLOWS.values():
-                workflow().get_description()
-        elif args.endpoint_params:
-            # Prevent DCS from running this endpoint if necessary, and print proper steps to take instead.
-            self.safeguards.verify(args.endpoint_params)
-            self.get_endpoint_params(args.endpoint_params)
-        elif args.workflow_params:
-            try:
-                # Finds workflow inherited class in dictionary if exists, and initializes it.
-                workflow = SUPPORTED_WORKFLOWS[args.workflow_params]()
-                workflow.init_parser()
-                workflow.get_info()
-            except KeyError as e:
-                raise KeyError(f"Error: '{args.workflow_params}' is not a supported workflow.")
+                raise KeyError(f"Error: '{args.workflow}' is not a supported workflow.")
         else:
             self.parser.print_help()
 

--- a/helpers/api.py
+++ b/helpers/api.py
@@ -5,7 +5,6 @@ import requests
 from . import auth
 
 
-
 class FerryAPI:
     def __init__(
         self: "FerryAPI",
@@ -31,8 +30,7 @@ class FerryAPI:
         headers: Dict[str, Any] = {},
         params: Dict[Any, Any] = {},
         extra: Dict[Any, Any] = {},
-    ) -> str:
-        
+    ) -> Any:
         # Create a session object to persist certain parameters across requests
         if not self.quiet:
             print(f"\nCalling Endpoint: {self.base_url}{endpoint}")
@@ -59,7 +57,7 @@ class FerryAPI:
             if not self.quiet:
                 print(f"Called Endpoint: {response.request.url}")
             output = response.json()
-            
+
             output["request_url"] = response.request.url
             return output
         except BaseException as e:

--- a/helpers/customs.py
+++ b/helpers/customs.py
@@ -6,6 +6,7 @@ import textwrap
 
 import toml
 
+
 class TConfig:
     def __init__(self) -> None:
         with open("config.toml", "r") as file:
@@ -28,15 +29,16 @@ class TConfig:
             if not check_path or (check_path and os.path.exists(retval))
             else default
         )
-    
+
+
 class FerryParser(argparse.ArgumentParser):
-    """Custom ArgumentParser used for parsing Ferry's swagger.json file and custom workflows into CLI arguments and objects
-    """
-    def __init__(self, **kwargs) -> None:
+    """Custom ArgumentParser used for parsing Ferry's swagger.json file and custom workflows into CLI arguments and objects"""
+
+    def __init__(self: "FerryParser", **kwargs) -> None:  # type: ignore
         super().__init__(**kwargs)
-        
-    def set_arguments(self, params:List[Dict[str, Any]]) -> None:
-        """Initializes arguments for the parser from the 
+
+    def set_arguments(self, params: List[Dict[str, Any]]) -> None:
+        """Initializes arguments for the parser from the
 
         Args:
             params (list): An array of Dictionary objects representing a parameter option
@@ -45,17 +47,17 @@ class FerryParser(argparse.ArgumentParser):
             req = "required" if param.get("required", False) else "optional"
             self.add_argument(
                 f"--{param['name']}",
-                type=str, 
+                type=str,
                 help=FerryParser.parse_description(
-                    name="", 
+                    name="",
                     description=param["description"],
-                    method=f"{param['type']}: {req}"
-                ), 
-                required=param.get("required", False)
+                    method=f"{param['type']}: {req}",
+                ),
+                required=param.get("required", False),
             )
-    
+
     @staticmethod
-    def create(description:str) -> 'FerryParser':
+    def create(description: str) -> "FerryParser":
         f"""Creates a FerryParser instance.
 
         Args:
@@ -65,9 +67,11 @@ class FerryParser(argparse.ArgumentParser):
             FerryParser
         """
         return FerryParser(description=description)
-    
+
     @staticmethod
-    def create_subparser(name:str, description:str, method:str="GET") -> 'FerryParser':
+    def create_subparser(
+        name: str, description: str, method: str = "GET"
+    ) -> "FerryParser":
         """Create a FerryParser subparser.
 
         Args:
@@ -80,21 +84,24 @@ class FerryParser(argparse.ArgumentParser):
         """
         description = FerryParser.parse_description(name, method, description)
         return FerryParser(description=description)
-    
+
     @staticmethod
-    def parse_description(name:str="Endpoint", method:str=None, description:str=None) -> str:
+    def parse_description(
+        name: str = "Endpoint", method: str = "", description: str = ""
+    ) -> str:
         description_lines = textwrap.wrap(description, width=60)
         first_line = description_lines[0]
         rest_lines = description_lines[1:]
         endpoint_description = "%s" % (name.replace("/", ""))
-        
+
         if len("(%s)" % method) <= 49:
             method_char_count = 49 - len("(%s)" % method)
         else:
             method_char_count = 0
 
-        endpoint_description = f"{endpoint_description:<{method_char_count}} ({method}) | {first_line}\n"
+        endpoint_description = (
+            f"{endpoint_description:<{method_char_count}} ({method}) | {first_line}\n"
+        )
         for line in rest_lines:
             endpoint_description += f"{'':<50} | {line}\n"
         return endpoint_description
-

--- a/helpers/supported_workflows/GetFilteredGroupInfo.py
+++ b/helpers/supported_workflows/GetFilteredGroupInfo.py
@@ -1,27 +1,34 @@
+from typing import Any, Dict
+
+from helpers.api import FerryAPI
 from helpers.workflows import Workflow
 
+
 class GetFilteredGroupInfo(Workflow):
-    def __init__(self):
+    def __init__(self: "GetFilteredGroupInfo") -> None:
         self.name = "getFilteredGroupInfo"
         self.method = "GET"
         self.description = "Returns gid, groupname, and grouptype for all groups with 'groupname' variable in its name."
         self.params = [
-                {
-                    "name":"groupname", 
-                    "description":"Name of the group", 
-                    "type":"string", 
-                    "required":True
-                }
-            ]
-        super().__init__(self)
+            {
+                "name": "groupname",
+                "description": "Name of the group",
+                "type": "string",
+                "required": True,
+            }
+        ]
+        super().__init__()
 
-    def run(self, api, args):
+    def run(self, api, args):  # type: ignore
         group_json = api.call_endpoint("getAllGroups")
         if not group_json:
             print(f"Failed'")
             exit(1)
         print(f"Recieved successful response")
         print(f"Filtering by groupname: '{args['groupname']}'")
-        group_info = [entry for entry in group_json["ferry_output"] if entry["groupname"] == args["groupname"]]
+        group_info = [
+            entry
+            for entry in group_json["ferry_output"]
+            if entry["groupname"] == args["groupname"]
+        ]
         return group_info
-    

--- a/helpers/workflows.py
+++ b/helpers/workflows.py
@@ -21,13 +21,9 @@ class Workflow(ABC):
         self.parser.set_arguments(self.params)
 
     def get_info(self) -> None:
-        if not self.parser:
-            self.init_parser()
         self.parser.print_help()
 
     def get_description(self) -> None:
-        if not self.parser:
-            self.init_parser()
         print(self.parser.description)
 
     @abstractmethod

--- a/helpers/workflows.py
+++ b/helpers/workflows.py
@@ -1,33 +1,36 @@
 from abc import ABC, abstractmethod
 from helpers.api import FerryAPI
 from helpers.customs import FerryParser
-from typing import Any
+from typing import Any, Dict, List, Optional
+
 
 class Workflow(ABC):
-    """Abstracted Workflow object that as the baseline for our custom workflows
-    """
-    def __init__(self, supported_workflow:'Workflow' = None) -> 'Workflow':
-        self.name = supported_workflow.name if supported_workflow else None
-        self.description = supported_workflow.description if supported_workflow else None
-        self.method = supported_workflow.method if supported_workflow else None
-        self.params = supported_workflow.params if supported_workflow else None
-        self.parser = None
-        
+    """Abstracted Workflow object that as the baseline for our custom workflows"""
+
+    def __init__(self) -> None:
+        self.name: str
+        self.description: str
+        self.method: str
+        self.params: List[Dict[str, Any]]
+        self.init_parser()
+
     def init_parser(self) -> None:
-        self.parser = FerryParser.create_subparser(name=self.name, description=self.description, method=self.method)
+        self.parser = FerryParser.create_subparser(
+            name=self.name, description=self.description, method=self.method
+        )
         self.parser.set_arguments(self.params)
-    
+
     def get_info(self) -> None:
         if not self.parser:
             self.init_parser()
         self.parser.print_help()
-        
+
     def get_description(self) -> None:
         if not self.parser:
             self.init_parser()
         print(self.parser.description)
-    
+
     @abstractmethod
-    def run(self, api:FerryAPI, *args) -> Any:
+    def run(self, api, *args):  # type: ignore
         # This method should be implemented by all subclasses
         pass

--- a/workflows/clone_resource.py
+++ b/workflows/clone_resource.py
@@ -1,4 +1,4 @@
-#from argparse import Namespace, ArgumentParser
+from argparse import Namespace, ArgumentParser
 import json
 
 from helpers.api import FerryAPI


### PR DESCRIPTION
Basically, every time we say
```python
if args.blah:
    bunch_of_printed_stuff()
```

we might as well make that a callback function.  That leaves only the `if args.endpoint` and `elif args.workflow` conditionals under the `FerryCLI.run` method, which makes sense, since those are the ones that are actually running something.

Note:  A lot of these changes are to make mypy happy.  The functional changes introduced here are in `ferry.py`

I tested this with the unit/integration tests, as well as running the `-le`, `-e`, `-ep`, `-lw`, `-w`, and `-wp` flags.  This also passes all the pre-commit checks.