### PR TITLE
added more constructive error messages to the failure to authenticate…

### DIFF
--- a/helpers/auth.py
+++ b/helpers/auth.py
@@ -88,7 +88,8 @@ class AuthToken(Auth):
     """This is a callable class that modifies a requests.Session object to add token
     auth"""
 
-    def __init__(self: "AuthToken", token_path: Optional[str] = None) -> None:
+    def __init__(self: "AuthToken", token_path: Optional[str] = None, debug: bool = False) -> None:
+        self.debug = debug
         try:
             self.token_string = (
                     get_default_token_string()


### PR DESCRIPTION
After talking about how we want to automate credential getting in #14 ,we decided not to and instead added a more helpful error message to help users recover from a failure to connect instead of trying to handle authentication for them.