### PR TITLE
Integration tests use FerryAPI class to call FERRY

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -161,9 +161,9 @@ class FerryCLI:
                 for name, workflow in SUPPORTED_WORKFLOWS.items():
                     if filter_args.filter:
                         if filter_args.filter.lower() in name.lower():
-                            workflow().get_description()  # type: ignore
+                            workflow().get_description()
                     else:
-                        workflow().get_description()  # type: ignore
+                        workflow().get_description()
 
                 sys.exit(0)
 
@@ -191,7 +191,7 @@ class FerryCLI:
             ) -> None:
                 try:
                     # Finds workflow inherited class in dictionary if exists, and initializes it.
-                    workflow = SUPPORTED_WORKFLOWS[values]()  # type: ignore
+                    workflow = SUPPORTED_WORKFLOWS[values]()
                     workflow.init_parser()
                     workflow.get_info()
                     sys.exit(0)
@@ -297,7 +297,7 @@ class FerryCLI:
         elif args.workflow:
             try:
                 # Finds workflow inherited class in dictionary if exists, and initializes it.
-                workflow = SUPPORTED_WORKFLOWS[args.workflow]()  # type: ignore
+                workflow = SUPPORTED_WORKFLOWS[args.workflow]()
                 workflow.init_parser()
                 workflow_params, _ = workflow.parser.parse_known_args(endpoint_args)
                 json_result = workflow.run(self.ferry_api, vars(workflow_params))  # type: ignore

--- a/ferry_cli/helpers/supported_workflows/__init__.py
+++ b/ferry_cli/helpers/supported_workflows/__init__.py
@@ -1,15 +1,19 @@
 # __init__.py
+from typing import Mapping, Type
+
 try:
+    from ferry_cli.helpers.workflows import Workflow
     from ferry_cli.helpers.supported_workflows.CloneResource import CloneResource
     from ferry_cli.helpers.supported_workflows.GetFilteredGroupInfo import (
         GetFilteredGroupInfo,
     )
 except ImportError:
+    from helpers.workflows import Workflow  # type: ignore
     from helpers.supported_workflows.CloneResource import CloneResource  # type: ignore
     from helpers.supported_workflows.GetFilteredGroupInfo import GetFilteredGroupInfo  # type: ignore
 
 
-SUPPORTED_WORKFLOWS = {
+SUPPORTED_WORKFLOWS: Mapping[str, Type[Workflow]] = {
     "cloneResource": CloneResource,
     "getFilteredGroupInfo": GetFilteredGroupInfo,
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,14 @@
+import pytest
+
+from ferry_cli.__main__ import FerryCLI
+
+
+@pytest.mark.unit
+def test_sanitize_base_url():
+    cases = ["http://hostname.domain:1234/", "http://hostname.domain:1234"]
+    expected = "http://hostname.domain:1234/"
+    for case in cases:
+        assert FerryCLI._sanitize_base_url(case) == expected
+
+    complex_case = "http://hostname.domain:1234/apiEndpoint?key1=val1"
+    assert FerryCLI._sanitize_base_url(complex_case) == complex_case


### PR DESCRIPTION
Closes #34 

Three changes here: 

1. Integration tests now use `FerryAPI` class method to call FERRY
2. Test tokens live in a temp area and are cleaned up
3. Sanitize our base URL to make sure it's valid