### PR TITLE
Create config file copy in XDG_CONFIG_HOME or HOME and use that config file in FerryCLI class

### DIFF
--- a/.github/workflows/Ferry-CLI.yml
+++ b/.github/workflows/Ferry-CLI.yml
@@ -5,6 +5,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  workflow_dispatch:
 
 
 jobs:

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -235,7 +235,7 @@ class FerryCLI:
 
     def generate_endpoints(self: "FerryCLI") -> Dict[str, FerryParser]:
         endpoints = {}
-        with open(f"{CONFIG_DIR}/config/swagger.json", "r") as json_file:
+        with open(f"{CONFIG_DIR}/swagger.json", "r") as json_file:
 
             api_data = json.load(json_file)
             for path, data in api_data["paths"].items():
@@ -355,7 +355,7 @@ def main() -> None:
             ferry_cli.get_arg_parser().print_help()
             sys.exit(0)
         ferry_cli.authorizer = set_auth_from_args(auth_args)
-        if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/config/swagger.json"):
+        if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
             print("Fetching latest swagger file...")
             ferry_cli.ferry_api = FerryAPI(
                 ferry_cli.base_url, ferry_cli.authorizer, auth_args.quiet

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -1,6 +1,8 @@
 import argparse
+import configparser
 import json
 import os
+import pathlib
 import sys
 import textwrap
 from typing import Any, Dict, Optional, List
@@ -19,7 +21,7 @@ try:
     from ferry_cli.helpers.customs import FerryParser
     from ferry_cli.helpers.supported_workflows import SUPPORTED_WORKFLOWS
     from ferry_cli.safeguards.dcs import SafeguardsDCS
-    from ferry_cli.config import CONFIG_DIR
+    from ferry_cli.config import CONFIG_DIR, config
 except ImportError:
     # Fallback to direct import
     from helpers.api import FerryAPI  # type: ignore
@@ -32,16 +34,18 @@ except ImportError:
     from helpers.customs import FerryParser  # type: ignore
     from helpers.supported_workflows import SUPPORTED_WORKFLOWS  # type: ignore
     from safeguards.dcs import SafeguardsDCS  # type: ignore
-    from config import CONFIG_DIR  # type: ignore
+    from config import CONFIG_DIR, config  # type: ignore
 
 
 class FerryCLI:
-    def __init__(self: "FerryCLI") -> None:
-        self.base_url = "https://ferry.fnal.gov:8445/"
+    # pylint: disable=too-many-instance-attributes
+    def __init__(self: "FerryCLI", config_path: pathlib.Path) -> None:
+        self.base_url: str
+        self.dev_url: str
+        self.config_path = config_path
+        self.configs = self.__parse_config_file()
         self.base_url = self._sanitize_base_url(self.base_url)
-        self.dev_url = "https://ferrydev.fnal.gov:8447/"
         self.dev_url = self._sanitize_base_url(self.dev_url)
-
         self.safeguards = SafeguardsDCS()
         self.endpoints: Dict[str, Any] = {}
         self.authorizer: Optional["Auth"] = None
@@ -278,6 +282,7 @@ class FerryCLI:
 
         if debug:
             print(f"Args:  {vars(args)}\n" f"Endpoint Args:  {endpoint_args}")
+            print(f"Using FERRY base url: {self.base_url}")
 
         if not self.ferry_api:
             self.ferry_api = FerryAPI(
@@ -346,9 +351,37 @@ class FerryCLI:
         )
         return urlunsplit(parts)
 
+    def __parse_config_file(self: "FerryCLI") -> configparser.ConfigParser:
+        configs = configparser.ConfigParser()
+        with open(self.config_path, "r") as f:
+            configs.read_file(f)
+
+        _base_url = configs.get("api", "base_url", fallback=None)
+        if _base_url is None:
+            raise ValueError(
+                f"api.base_url must be specified in the config file at {self.config_path}. "
+                "Please set that value adn try again."
+            )
+        self.base_url = _base_url.strip().strip('"')
+
+        _dev_url = configs.get("api", "dev_url", fallback=None)
+        if _dev_url is not None:
+            self.dev_url = _dev_url.strip().strip('"')
+
+        return configs
+
 
 def main() -> None:
-    ferry_cli = FerryCLI()
+    config.create_configfile_if_not_exists()
+    config_path = config.get_configfile_path()
+    if config_path is None:
+        raise TypeError(
+            "Config path could not be found.  Please check to make sure that the "
+            "configuration file is located at $XDG_CONFIG_HOME/ferry_cli/config.ini "
+            "or $HOME/.config/ferry_cli/config.ini."
+        )
+
+    ferry_cli = FerryCLI(config_path=config_path)
     try:
         auth_args, other_args = get_auth_args()
         if not other_args or ("-h" in other_args) or ("--help" in other_args):

--- a/ferry_cli/config/__init__.py
+++ b/ferry_cli/config/__init__.py
@@ -1,4 +1,4 @@
 # __init__.py
 import os
 
-CONFIG_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+CONFIG_DIR = os.path.dirname(os.path.abspath(__file__))

--- a/ferry_cli/config/config.ini
+++ b/ferry_cli/config/config.ini
@@ -8,6 +8,9 @@
 # Endpoint requests are formatted as: f"{base_url}{endpoint}"
 base_url = "https://sample_swagger_site.com/"
 
+# Define an optional dev instance url to be used instead of base_url
+dev_url = "https://sample_swagger_site-dev.com/"
+
 # Define url to your swagger.json
 # This is the path that we use to download your swagger.json file during setup, and to fetch newer versions.
 # EVERYTHING in this cli is built off of this file

--- a/ferry_cli/config/config.py
+++ b/ferry_cli/config/config.py
@@ -23,6 +23,7 @@ def create_configfile_if_not_exists() -> None:
     home_path = _get_configfile_path_home()
     dest_path = xdg_path if xdg_path else home_path
     if dest_path:
+        dest_path.parent.mkdir(parents=True, exist_ok=True)
         shutil.copy(_get_template_path(), dest_path)
         print(f"Configuration file created at {dest_path.absolute()}")
         return

--- a/ferry_cli/config/config.py
+++ b/ferry_cli/config/config.py
@@ -24,6 +24,7 @@ def create_configfile_if_not_exists() -> None:
     dest_path = xdg_path if xdg_path else home_path
     if dest_path:
         shutil.copy(_get_template_path(), dest_path)
+        print(f"Configuration file created at {dest_path.absolute()}")
         return
     raise OSError(
         "XDG_CONFIG_HOME or HOME needs to be set to copy the template config file into place"

--- a/ferry_cli/config/config.py
+++ b/ferry_cli/config/config.py
@@ -1,0 +1,69 @@
+import os
+import pathlib
+import shutil
+from typing import Optional
+
+try:
+    from ferry_cli.config import CONFIG_DIR
+except ImportError:
+    from config import CONFIG_DIR  # type: ignore
+
+__config_path_post_basedir = pathlib.Path("ferry_cli/config.ini")
+
+
+def create_configfile_if_not_exists() -> None:
+    # Creates a copy of the configuration template in ${XDG_CONFIG_HOME}/ferry_cli/config.ini,
+    # or ${HOME}/.config/ferry_cli/config.ini if $XDG_CONFIG_HOME is not set.
+    # If $HOME is not set for some reason, this raises an OSError
+    if configfile_exists():
+        return
+
+    dest_path: Optional[pathlib.Path]
+    xdg_path = _get_configfile_path_xdg_config_home()
+    home_path = _get_configfile_path_home()
+    dest_path = xdg_path if xdg_path else home_path
+    if dest_path:
+        shutil.copy(_get_template_path(), dest_path)
+        return
+    raise OSError(
+        "XDG_CONFIG_HOME or HOME needs to be set to copy the template config file into place"
+    )
+
+
+def configfile_exists() -> bool:
+    # A helper function to bridge get_configfile_path() to simply query if the configfile exists
+    return get_configfile_path() is not None
+
+
+def get_configfile_path() -> Optional[pathlib.Path]:
+    # Try $XDG_CONFIG_HOME/ferry_cli, then $HOME/.config/ferry_cli to
+    # find config.ini, and return the pathlib.Path pointing to the config file.
+    # If neither directory has config.ini, return None to indicate that the config
+    # file doesn't exist
+    xdg_path = _get_configfile_path_xdg_config_home()
+    if xdg_path and xdg_path.exists():
+        return xdg_path
+
+    home_path = _get_configfile_path_home()
+    if home_path and home_path.exists():
+        return home_path
+
+    return None
+
+
+def _get_configfile_path_xdg_config_home() -> Optional[pathlib.Path]:
+    xdg_config_home_val = os.getenv("XDG_CONFIG_HOME")
+    if not xdg_config_home_val:
+        return None
+    return pathlib.Path(xdg_config_home_val) / __config_path_post_basedir
+
+
+def _get_configfile_path_home() -> Optional[pathlib.Path]:
+    home = os.getenv("HOME")
+    if not home:
+        return None
+    return pathlib.Path(home) / ".config" / __config_path_post_basedir
+
+
+def _get_template_path() -> pathlib.Path:
+    return pathlib.Path(CONFIG_DIR) / "config.ini"

--- a/ferry_cli/helpers/api.py
+++ b/ferry_cli/helpers/api.py
@@ -88,7 +88,7 @@ class FerryAPI:
 
         response = self.call_endpoint("docs/swagger.json")
         if response:
-            with open(f"{CONFIG_DIR}/config/swagger.json", "w") as file:
+            with open(f"{CONFIG_DIR}/swagger.json", "w") as file:
                 file.write(json.dumps(response, indent=4))
         else:
             print("Failed to fetch swagger.json file")

--- a/ferry_cli/version.py
+++ b/ferry_cli/version.py
@@ -25,8 +25,8 @@ def get_summary() -> str:
 
 def print_version(full: bool = False, short: bool = False) -> Optional[str]:
     file_version = None
-    if os.path.exists(f"{CONFIG_DIR}/config/swagger.json"):
-        with open(f"{CONFIG_DIR}/config/swagger.json", "r") as file:
+    if os.path.exists(f"{CONFIG_DIR}/swagger.json"):
+        with open(f"{CONFIG_DIR}/swagger.json", "r") as file:
             json_file = json.load(file)
             file_version = json_file.get("info", {}).get("version", None)
     if short:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,8 @@ import pytest
 def stash_env():
     def inner(env_var):
         env_previous = os.getenv(env_var)
+        if env_previous:
+            del os.environ[env_var]
         yield
         if env_previous:
             os.environ[env_var] = env_previous

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,9 +6,9 @@ import pytest
 @pytest.fixture
 def stash_env():
     def inner(env_var):
-        xdg_previous = os.getenv(env_var)
+        env_previous = os.getenv(env_var)
         yield
-        if xdg_previous:
-            os.environ[env_var] = xdg_previous
+        if env_previous:
+            os.environ[env_var] = env_previous
 
     return inner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,11 +4,10 @@ import pytest
 
 
 @pytest.fixture
-def stash_env():
+def stash_env(monkeypatch):
     def inner(env_var):
         env_previous = os.getenv(env_var)
-        if env_previous:
-            del os.environ[env_var]
+        monkeypatch.delenv(env_var, raising=False)
         yield
         if env_previous:
             os.environ[env_var] = env_previous

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import os
+
+import pytest
+
+
+@pytest.fixture
+def stash_env():
+    def inner(env_var):
+        xdg_previous = os.getenv(env_var)
+        yield
+        if xdg_previous:
+            os.environ[env_var] = xdg_previous
+
+    return inner

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,164 @@
+from collections import namedtuple
+import enum
+import pathlib
+from typing import List
+
+import pytest
+
+from ferry_cli.config import CONFIG_DIR, config
+
+
+@pytest.fixture
+def stash_xdg_config_home(stash_env):
+    return stash_env("XDG_CONFIG_HOME")
+
+
+@pytest.fixture
+def stash_home(stash_env):
+    return stash_env("HOME")
+
+
+@pytest.fixture
+def create_config_file_dummy():
+    def inner(env_path: pathlib.Path, *path_parts_to_base_dir: List[str]) -> None:
+        base_dir = env_path
+        for part in path_parts_to_base_dir:
+            base_dir = base_dir / part
+        base_dir.mkdir(parents=True)
+        path_to_file = base_dir / "config.ini"
+        path_to_file.touch()
+
+    return inner
+
+
+@pytest.mark.unit
+def test_get_configfile_xdg_config_home_(
+    stash_xdg_config_home, create_config_file_dummy, tmp_path, monkeypatch
+):
+    assert not config._get_configfile_path_xdg_config_home()
+    env_path = tmp_path
+    create_config_file_dummy(env_path, "ferry_cli")
+    monkeypatch.setenv("XDG_CONFIG_HOME", env_path)
+
+    assert config._get_configfile_path_xdg_config_home() == pathlib.Path(
+        f"{env_path}/ferry_cli/config.ini"
+    )
+
+
+@pytest.mark.unit
+def test_get_configfile_home(
+    stash_home, create_config_file_dummy, tmp_path, monkeypatch
+):
+    env_path = tmp_path
+    create_config_file_dummy(env_path, ".config", "ferry_cli")
+    monkeypatch.setenv("HOME", env_path)
+
+    assert config._get_configfile_path_home() == pathlib.Path(
+        f"{env_path}/.config/ferry_cli/config.ini"
+    )
+
+
+class _expectedPathRoot(enum.Enum):
+    XDG_CONFIG_HOME = 1
+    HOME = 2
+    NOT_FOUND = 3
+
+
+configfile_test_param = namedtuple(
+    "configfile_test_param",
+    [
+        "xdg_config_home_path",
+        "xdg_path_exists",
+        "home_config_path",
+        "home_path_exists",
+        "expected",
+    ],
+)
+
+get_configfile_params_for_test = [
+    configfile_test_param(True, False, False, False, _expectedPathRoot.NOT_FOUND),
+    configfile_test_param(True, False, True, False, _expectedPathRoot.NOT_FOUND),
+    configfile_test_param(True, True, False, False, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_test_param(True, True, True, False, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_test_param(True, True, True, True, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_test_param(False, False, True, False, _expectedPathRoot.NOT_FOUND),
+    configfile_test_param(False, False, True, True, _expectedPathRoot.HOME),
+    configfile_test_param(False, False, False, False, _expectedPathRoot.NOT_FOUND),
+]
+
+
+@pytest.mark.parametrize(
+    "param_val",
+    get_configfile_params_for_test,
+)
+@pytest.mark.unit
+def test_get_configfile_path(
+    stash_xdg_config_home,
+    stash_home,
+    tmp_path,
+    monkeypatch,
+    create_config_file_dummy,
+    param_val,
+):
+    xdg_path = tmp_path
+    home_path = tmp_path
+
+    if param_val.xdg_config_home_path:
+        monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
+        if param_val.xdg_path_exists:
+            create_config_file_dummy(xdg_path, "ferry_cli")
+
+    if param_val.home_config_path:
+        monkeypatch.setenv("HOME", home_path)
+        if param_val.home_path_exists:
+            create_config_file_dummy(xdg_path, ".config", "ferry_cli")
+
+    if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
+        expectedPath = xdg_path / "ferry_cli" / "config.ini"
+        assert config.get_configfile_path() == expectedPath
+    elif param_val.expected == _expectedPathRoot.HOME:
+        expectedPath = home_path / ".config" / "ferry_cli" / "config.ini"
+        assert config.get_configfile_path() == expectedPath
+    else:
+        assert not config.get_configfile_path()
+
+
+@pytest.mark.unit
+def test_get_template_path():
+    assert config._get_template_path() == pathlib.Path(f"{CONFIG_DIR}/config.ini")
+
+
+@pytest.mark.parametrize(
+    "config_exists",
+    [(True), (False)],
+)
+@pytest.mark.unit
+def test_create_configfile_if_not_exists(
+    stash_xdg_config_home,
+    tmp_path,
+    monkeypatch,
+    create_config_file_dummy,
+    config_exists,
+):
+    env_path = tmp_path
+    monkeypatch.setenv("XDG_CONFIG_HOME", env_path)
+
+    if config_exists:
+        create_config_file_dummy(env_path, "ferry_cli")
+    else:
+        basepath = env_path / "ferry_cli"
+        basepath.mkdir()
+
+    config.create_configfile_if_not_exists()
+    assert config.get_configfile_path().exists()
+
+
+@pytest.mark.parametrize(
+    "mockFn,expected", [(lambda: None, False), (lambda: pathlib.Path("/"), True)]
+)
+@pytest.mark.unit
+def test_configfile_exists(monkeypatch, mockFn, expected):
+    # Since all we care about in this test is that the return value of get_configfile_path
+    # is used appropriately, mock that return value to make the test simple
+    monkeypatch.setattr(config, "get_configfile_path", mockFn)
+    assert config.configfile_exists() == expected

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,10 +38,11 @@ def create_config_file_dummy():
 def test_get_configfile_xdg_config_home_(
     stash_xdg_config_home, create_config_file_dummy, tmp_path, monkeypatch
 ):
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     assert not config._get_configfile_path_xdg_config_home()
     env_path = tmp_path
-    create_config_file_dummy(env_path, "ferry_cli")
     monkeypatch.setenv("XDG_CONFIG_HOME", env_path)
+    create_config_file_dummy(env_path, "ferry_cli")
 
     assert config._get_configfile_path_xdg_config_home() == pathlib.Path(
         f"{env_path}/ferry_cli/config.ini"
@@ -52,6 +53,7 @@ def test_get_configfile_xdg_config_home_(
 def test_get_configfile_home(
     stash_home, create_config_file_dummy, tmp_path, monkeypatch
 ):
+    monkeypatch.delenv("HOME", raising=False)
     env_path = tmp_path
     create_config_file_dummy(env_path, ".config", "ferry_cli")
     monkeypatch.setenv("HOME", env_path)
@@ -103,10 +105,14 @@ def test_get_configfile_path(
     create_config_file_dummy,
     param_val,
 ):
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
     xdg_path = tmp_path
     home_path = tmp_path
-    monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
-    monkeypatch.setenv("HOME", home_path)
+    if param_val.xdg_config_home_path:
+        monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
+    if param_val.home_config_path:
+        monkeypatch.setenv("HOME", home_path)
 
     if param_val.xdg_path_exists:
         create_config_file_dummy(xdg_path, "ferry_cli")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,10 @@
 from collections import namedtuple
 import enum
 import pathlib
+import importlib
 from typing import List
+
+import os
 
 import pytest
 
@@ -102,16 +105,14 @@ def test_get_configfile_path(
 ):
     xdg_path = tmp_path
     home_path = tmp_path
+    monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
+    monkeypatch.setenv("HOME", home_path)
 
-    if param_val.xdg_config_home_path:
-        monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
-        if param_val.xdg_path_exists:
-            create_config_file_dummy(xdg_path, "ferry_cli")
+    if param_val.xdg_path_exists:
+        create_config_file_dummy(xdg_path, "ferry_cli")
 
-    if param_val.home_config_path:
-        monkeypatch.setenv("HOME", home_path)
-        if param_val.home_path_exists:
-            create_config_file_dummy(xdg_path, ".config", "ferry_cli")
+    if param_val.home_path_exists:
+        create_config_file_dummy(xdg_path, ".config", "ferry_cli")
 
     if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
         expectedPath = xdg_path / "ferry_cli" / "config.ini"


### PR DESCRIPTION
Closes #70 

This PR includes a couple of changes.

1. Created funcs in new file ferry_cli/config/config.py to locate config file in `${XDG_CONFIG_HOME:-HOME/.config}/ferry_cli` and copy a new one from `ferry_cli/config/config.ini` if it does not exist.
2. Reworked `__main__.py` to use funcs from (1) to ensure a config file exists in the appropriate location, and use it in the `FerryCLI` class to set `base_url` and `dev_url`.

Two notes:
1.  Upon commit e46bd - 4 mypy failures were recorded with regards to the ferry_cli/helpers/supported_workflows/__init__.py file. These are actually fixed in #67, so after I corrected all the other errors that pre-commit reported, I skipped verification for this commit. If reviewers prefer, we can wait until #67 is merged, and then a rebasing of this branch on top of the new master should fix those mypy errors.
2. The user workflow right now is to run a ferry-cli command, which will fail because the configfile will have the wrong base url (namely the one from the template). The user will manually have to change the config file, and then try to run ferry-cli again. At that point, it should work.  This is not the final workflow. The interactive mode that will eliminate the need for this step will be implemented in #72.
