### PR TITLE
If configfile doesn't exist, read in a template, and fill in string values from future interactiv mode

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -371,9 +371,19 @@ class FerryCLI:
         return configs
 
 
+# TODO To be implemented in #72 # pylint: disable=fixme
+def get_config_info_from_user() -> Dict[str, str]:
+    return {}
+
+
 def main() -> None:
-    config.create_configfile_if_not_exists()
-    config_path = config.get_configfile_path()
+    _config_path = config.get_configfile_path()
+    if (_config_path is not None) and (_config_path.exists):
+        config_path = config.get_configfile_path()
+    else:
+        config_values = get_config_info_from_user()
+        config_path = config.write_out_configfile(config_values)
+
     if config_path is None:
         raise TypeError(
             "Config path could not be found.  Please check to make sure that the "

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -378,7 +378,7 @@ def get_config_info_from_user() -> Dict[str, str]:
 
 def main() -> None:
     _config_path = config.get_configfile_path()
-    if (_config_path is not None) and (_config_path.exists):
+    if (_config_path is not None) and (_config_path.exists()):
         config_path = config.get_configfile_path()
     else:
         config_values = get_config_info_from_user()

--- a/ferry_cli/config/config.ini
+++ b/ferry_cli/config/config.ini
@@ -1,15 +1,17 @@
 # ferry_cli/config/config.ini
+# Note:  This is a template.  Currently, the only supported key is base_url.  The rest can be changed
+# manually
 
 [api]
 # Set the base configurations for your swagger api.
 # Note: This tool is tailored specifically to support the json structure utilized by swagger api's
 #           Other formats have not been tested, and there are no plans at this time to support them.
 
-# Endpoint requests are formatted as: f"{base_url}{endpoint}"
-base_url = "https://sample_swagger_site.com/"
+# Endpoint requests are formatted as: "base_url"/"endpoint"
+base_url = {base_url}
 
 # Define an optional dev instance url to be used instead of base_url
-dev_url = "https://sample_swagger_site-dev.com/"
+dev_url = {dev_url}
 
 # Define url to your swagger.json
 # This is the path that we use to download your swagger.json file during setup, and to fetch newer versions.

--- a/ferry_cli/config/config.py
+++ b/ferry_cli/config/config.py
@@ -1,7 +1,6 @@
 import os
 import pathlib
-import shutil
-from typing import Optional
+from typing import Optional, Dict
 
 try:
     from ferry_cli.config import CONFIG_DIR
@@ -11,46 +10,58 @@ except ImportError:
 __config_path_post_basedir = pathlib.Path("ferry_cli/config.ini")
 
 
-def create_configfile_if_not_exists() -> None:
-    # Creates a copy of the configuration template in ${XDG_CONFIG_HOME}/ferry_cli/config.ini,
-    # or ${HOME}/.config/ferry_cli/config.ini if $XDG_CONFIG_HOME is not set.
-    # If $HOME is not set for some reason, this raises an OSError
-    if configfile_exists():
-        return
+# def create_configfile_if_not_exists() -> None:
+#     # Creates a copy of the configuration template in ${XDG_CONFIG_HOME}/ferry_cli/config.ini,
+#     # or ${HOME}/.config/ferry_cli/config.ini if $XDG_CONFIG_HOME is not set.
+#     # If $HOME is not set for some reason, this raises an OSError
+#     if configfile_exists():
+#         return
 
-    dest_path: Optional[pathlib.Path]
-    xdg_path = _get_configfile_path_xdg_config_home()
-    home_path = _get_configfile_path_home()
-    dest_path = xdg_path if xdg_path else home_path
-    if dest_path:
-        dest_path.parent.mkdir(parents=True, exist_ok=True)
-        shutil.copy(_get_template_path(), dest_path)
-        print(f"Configuration file created at {dest_path.absolute()}")
-        return
-    raise OSError(
-        "XDG_CONFIG_HOME or HOME needs to be set to copy the template config file into place"
-    )
-
-
-def configfile_exists() -> bool:
-    # A helper function to bridge get_configfile_path() to simply query if the configfile exists
-    return get_configfile_path() is not None
+#     dest_path: Optional[pathlib.Path]
+#     xdg_path = _get_configfile_path_xdg_config_home()
+#     home_path = _get_configfile_path_home()
+#     dest_path = xdg_path if xdg_path else home_path
+#     if dest_path:
+#         dest_path.parent.mkdir(parents=True, exist_ok=True)
+#         shutil.copy(_get_template_path(), dest_path)
+#         print(f"Configuration file created at {dest_path.absolute()}")
+#         return
+#     raise OSError(
+#         "XDG_CONFIG_HOME or HOME needs to be set to copy the template config file into place"
+#     )
 
 
 def get_configfile_path() -> Optional[pathlib.Path]:
-    # Try $XDG_CONFIG_HOME/ferry_cli, then $HOME/.config/ferry_cli to
-    # find config.ini, and return the pathlib.Path pointing to the config file.
-    # If neither directory has config.ini, return None to indicate that the config
-    # file doesn't exist
+    """
+    Return the location of the configfile.  If $XDG_CONFIG_HOME is set,
+    its value is used as the root for the config file path.  Otherwise,
+    $HOME/.config is used.  If for some reason $HOME is not set,
+    this function will return None.
+
+    Equivalent to the shell call
+    echo ${XDG_CONFIG_HOME:-HOME/.config}/ferry_cli/config.ini
+
+    Note that this call does NOT guarantee that the file actually exists at the returned path.
+    That should be ascertained by checking the return value against None, and then
+    using the pathlib.Path.exists() method
+    """
+
+    # TODO:  Once SL7 EOL has passed, change these into assignment expressions. # pylint: disable=fixme
+    # e.g. if (xdg_path := _get_configfile_path_xdg_config_home()): return xdg_path
     xdg_path = _get_configfile_path_xdg_config_home()
-    if xdg_path and xdg_path.exists():
+    if xdg_path:
         return xdg_path
 
     home_path = _get_configfile_path_home()
-    if home_path and home_path.exists():
+    if home_path:
         return home_path
 
     return None
+
+
+# pylint:disable=unused-argument
+def write_out_configfile(config_values: Dict[str, str]) -> pathlib.Path:
+    return pathlib.Path()
 
 
 def _get_configfile_path_xdg_config_home() -> Optional[pathlib.Path]:

--- a/tests/data/test_config_template
+++ b/tests/data/test_config_template
@@ -1,0 +1,6 @@
+This is a {good_key} template
+This is another line
+
+# Commented line
+[section]
+key={good_value}

--- a/tests/data/write_out_configfile_template_tests
+++ b/tests/data/write_out_configfile_template_tests
@@ -1,0 +1,22 @@
+[
+    {
+        "config_vals": {},
+        "file_contents": "This is a {good_key} template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+    },
+    {
+        "config_vals": {"good_key": "foo", "good_value": "bar"},
+        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey=bar"
+    },
+    {
+        "config_vals": {"good_key": "foo"},
+        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+    },
+    {
+        "config_vals": {"good_key": "foo", "bad_key": "bar"},
+        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+    },
+    {
+        "config_vals": {"bad_key1": "foo", "bad_key2": "bar"},
+        "file_contents": "This is a {good_key} template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+    }
+]

--- a/tests/data/write_out_configfile_template_tests
+++ b/tests/data/write_out_configfile_template_tests
@@ -1,22 +1,22 @@
 [
     {
         "config_vals": {},
-        "file_contents": "This is a {good_key} template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+        "file_contents": "This is a {good_key} template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}\n"
     },
     {
         "config_vals": {"good_key": "foo", "good_value": "bar"},
-        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey=bar"
+        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey=bar\n"
     },
     {
         "config_vals": {"good_key": "foo"},
-        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}\n"
     },
     {
         "config_vals": {"good_key": "foo", "bad_key": "bar"},
-        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+        "file_contents": "This is a foo template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}\n"
     },
     {
         "config_vals": {"bad_key1": "foo", "bad_key2": "bar"},
-        "file_contents": "This is a {good_key} template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}"
+        "file_contents": "This is a {good_key} template\nThis is another line\n\n# Commented line\n[section]\nkey={good_value}\n"
     }
 ]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -73,22 +73,16 @@ configfile_test_param = namedtuple(
     "configfile_test_param",
     [
         "xdg_config_home_path",
-        "xdg_path_exists",
         "home_config_path",
-        "home_path_exists",
         "expected",
     ],
 )
 
 get_configfile_params_for_test = [
-    configfile_test_param(True, False, False, False, _expectedPathRoot.NOT_FOUND),
-    configfile_test_param(True, False, True, False, _expectedPathRoot.NOT_FOUND),
-    configfile_test_param(True, True, False, False, _expectedPathRoot.XDG_CONFIG_HOME),
-    configfile_test_param(True, True, True, False, _expectedPathRoot.XDG_CONFIG_HOME),
-    configfile_test_param(True, True, True, True, _expectedPathRoot.XDG_CONFIG_HOME),
-    configfile_test_param(False, False, True, False, _expectedPathRoot.NOT_FOUND),
-    configfile_test_param(False, False, True, True, _expectedPathRoot.HOME),
-    configfile_test_param(False, False, False, False, _expectedPathRoot.NOT_FOUND),
+    configfile_test_param(True, True, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_test_param(True, False, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_test_param(False, True, _expectedPathRoot.HOME),
+    configfile_test_param(False, False, _expectedPathRoot.NOT_FOUND),
 ]
 
 
@@ -113,12 +107,6 @@ def test_get_configfile_path(
         monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
     if param_val.home_config_path:
         monkeypatch.setenv("HOME", home_path)
-
-    if param_val.xdg_path_exists:
-        create_config_file_dummy(xdg_path, "ferry_cli")
-
-    if param_val.home_path_exists:
-        create_config_file_dummy(xdg_path, ".config", "ferry_cli")
 
     if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
         expectedPath = xdg_path / "ferry_cli" / "config.ini"


### PR DESCRIPTION
Closes #78 

This PR adds functionality to do the following:

1. Check to see if there is a configuration file in $XDG_CONFIG_HOME or $HOME/.config.
2. If not, get config values from a future feature (#72) that will return a dict of config values from prompting the user.
3. Read in a config template and fill in the values from (2)
4. Write the filled-in template out to the location in (1) for future use.

This also has a set of unit tests to test this functionality. 

## Extra test

 I also did the following test to make sure this works in the user workflow:

1.  Change the dummy function `__main__.py:get_config_info_from_user` to return `{"base_url":"https://<real_ferry_hostname>:<ferry_port>"}
2. Run `bin/ferry-cli -e getGroupInfo`.

As expected, a new configuration file was created at `$HOME/.config/ferry_cli/config.ini`, and the requested info was properly returned from FERRY.

I then reran (2), and it used the configuration file stored by the first run.  So this looks good.

@cathulhu - in #72, you should only need to replace `__main__.py:get_config_info_from_user` with the actual functionality (feel free to change the name if you want), and everything should work.