### PR TITLE
Added --show-config-file flag so users can see which configuration file is being used

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -101,28 +101,11 @@ class FerryCLI:
         parser.add_argument("-w", "--workflow", help="Execute supported workflows")
         parser.add_argument(
             "--show-config-file",
-            action=self.show_config_file(),
-            nargs=0,
-            help="Locate and print configuration file, if it exists",
+            action="store_true",
+            help="Locate and print configuration file, if it exists, then exit.",
         )
 
         return parser
-
-    def show_config_file(self: "FerryCLI"):  # type: ignore
-        class _ShowConfigFile(argparse.Action):
-            def __call__(  # type: ignore
-                self: "_ShowConfigFile", parser, args, values, option_string=None
-            ) -> None:
-                config_path = config.get_configfile_path()
-                if config_path is not None:
-                    print(f"Configuration file: {str(config_path.absolute())}")
-                else:
-                    print(
-                        'No configuration file found.  Please run "ferry_cli" and answer the prompts to generate a configuration file'
-                    )
-                sys.exit(0)
-
-        return _ShowConfigFile
 
     def list_available_endpoints_action(self: "FerryCLI"):  # type: ignore
         endpoints = self.endpoints
@@ -398,7 +381,32 @@ def get_config_info_from_user() -> Dict[str, str]:
     return {}
 
 
+# Check args for --show-config-file. If it's there, print the config file path if it exists and exit
+def handle_show_configfile(args: List[str]) -> None:
+    if not "--show-config-file" in args:
+        return
+
+    if "--help" in args or "-h" in args:
+        return
+
+    config_path = config.get_configfile_path()
+    if config_path is not None:
+        if not config_path.exists():
+            print(
+                f"Based on the environment, would use configuration file: {str(config_path.absolute())}.  However, that path does not exist."
+            )
+        else:
+            print(f"Configuration file: {str(config_path.absolute())}")
+    else:
+        print(
+            'No configuration file found.  Please run "ferry_cli" and answer the prompts to generate a configuration file'
+        )
+    sys.exit(0)
+
+
 def main() -> None:
+    handle_show_configfile(sys.argv)
+
     _config_path = config.get_configfile_path()
     if (_config_path is not None) and (_config_path.exists()):
         config_path = config.get_configfile_path()

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -99,8 +99,30 @@ class FerryCLI:
         )
         parser.add_argument("-e", "--endpoint", help="API endpoint and parameters")
         parser.add_argument("-w", "--workflow", help="Execute supported workflows")
+        parser.add_argument(
+            "--show-config-file",
+            action=self.show_config_file(),
+            nargs=0,
+            help="Locate and print configuration file, if it exists",
+        )
 
         return parser
+
+    def show_config_file(self: "FerryCLI"):  # type: ignore
+        class _ShowConfigFile(argparse.Action):
+            def __call__(  # type: ignore
+                self: "_ShowConfigFile", parser, args, values, option_string=None
+            ) -> None:
+                config_path = config.get_configfile_path()
+                if config_path is not None:
+                    print(f"Configuration file: {str(config_path.absolute())}")
+                else:
+                    print(
+                        'No configuration file found.  Please run "ferry_cli" and answer the prompts to generate a configuration file'
+                    )
+                sys.exit(0)
+
+        return _ShowConfigFile
 
     def list_available_endpoints_action(self: "FerryCLI"):  # type: ignore
         endpoints = self.endpoints

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,11 @@
+from collections import namedtuple
+import os.path
+import subprocess
+
 import pytest
 
-from ferry_cli.__main__ import FerryCLI
+from ferry_cli.__main__ import FerryCLI, handle_show_configfile
+import ferry_cli.config.config as _config
 
 
 @pytest.mark.unit
@@ -12,3 +17,116 @@ def test_sanitize_base_url():
 
     complex_case = "http://hostname.domain:1234/apiEndpoint?key1=val1"
     assert FerryCLI._sanitize_base_url(complex_case) == complex_case
+
+
+@pytest.mark.unit
+def test_handle_show_configfile_configfile_exists(capsys, monkeypatch, tmp_path):
+    p = tmp_path
+    config_dir = p / "ferry_cli"
+    config_dir.mkdir()
+    config_file = config_dir / "config.ini"
+    config_file.write_text("This is a fake config file")
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(p.absolute()))
+
+    test_case = namedtuple("TestCase", ["args", "expected_stdout_substr"])
+    args_cases = (
+        test_case(
+            ["--show-config-file", "--foo", "bar", "--baz"],  # Arg passed
+            f"Configuration file: {str(config_file.absolute())}",
+        ),
+        test_case(["--foo", "bar", "--baz"], ""),  # Arg not passed
+    )
+
+    for case in args_cases:
+        try:
+            handle_show_configfile(case.args)
+        except SystemExit:
+            pass
+        captured = capsys.readouterr()
+        assert captured.out.strip() == case.expected_stdout_substr
+
+
+@pytest.mark.unit
+def test_handle_show_configfile_configfile_does_not_exist(
+    capsys, monkeypatch, tmp_path
+):
+    p = tmp_path
+    config_dir = p / "ferry_cli"
+    config_dir.mkdir()
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(p.absolute()))
+
+    args = ["--show-config-file", "--foo", "bar", "--baz"]  # Arg passed
+
+    try:
+        handle_show_configfile(args)
+    except SystemExit:
+        pass
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == f"Based on the environment, would use configuration file: {str((config_dir / 'config.ini').absolute())}.  However, that path does not exist."
+    )
+
+
+@pytest.mark.unit
+def test_handle_show_configfile_not_found(capsys, monkeypatch):
+    monkeypatch.setattr(_config, "get_configfile_path", lambda: None)
+
+    args = ["--show-config-file", "--foo", "bar", "--baz"]  # Arg passed
+
+    try:
+        handle_show_configfile(args)
+    except SystemExit:
+        pass
+    captured = capsys.readouterr()
+    assert (
+        captured.out.strip()
+        == 'No configuration file found.  Please run "ferry_cli" and answer the prompts to generate a configuration file'
+    )
+
+
+@pytest.mark.unit
+def test_show_configfile_flag():
+    bindir = f"{os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}/bin"
+    exe = f"{bindir}/ferry-cli"
+    cmdargs = [exe, "-h"]
+
+    try:
+        proc = subprocess.run(cmdargs, capture_output=True)
+    except SystemExit:
+        pass
+
+    assert "--show-config-file" in str(proc.stdout)
+
+
+# Since we have to handle --show-config-file outside of argparse, make sure we get the correct behavior
+@pytest.mark.unit
+def test_show_configfile_flag_with_other_args():
+    bindir = f"{os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}/bin"
+    exe = f"{bindir}/ferry-cli"
+
+    test_case = namedtuple("TestCase", ["args", "expected_out_substr"])
+
+    cases = (
+        test_case(
+            [exe, "-h"], "--show-config-file"
+        ),  # If we pass -h, make sure --show-config-file shows up
+        test_case(
+            [exe, "-h", "--show-config-file", "-e", "getAllGroups"],
+            "--show-config-file",
+        ),  # If we pass -h and --show-config-file, -h should win
+        test_case(
+            [exe, "--show-config-file"], "Configuration file"
+        ),  # Print out config file if we only pass --show-config-file
+        test_case(
+            [exe, "--show-config-file", "-e", "getAllGroups"], "Configuration file"
+        ),  # If we pass --show-config-file with other args, --show-config-file should win
+    )
+
+    for case in cases:
+        try:
+            proc = subprocess.run(case.args, capture_output=True)
+        except SystemExit:
+            pass
+
+        assert case.expected_out_substr in str(proc.stdout)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -85,20 +85,6 @@ def test_handle_show_configfile_not_found(capsys, monkeypatch):
     )
 
 
-@pytest.mark.unit
-def test_show_configfile_flag():
-    bindir = f"{os.path.dirname(os.path.dirname(os.path.abspath(__file__)))}/bin"
-    exe = f"{bindir}/ferry-cli"
-    cmdargs = [exe, "-h"]
-
-    try:
-        proc = subprocess.run(cmdargs, capture_output=True)
-    except SystemExit:
-        pass
-
-    assert "--show-config-file" in str(proc.stdout)
-
-
 # Since we have to handle --show-config-file outside of argparse, make sure we get the correct behavior
 @pytest.mark.unit
 def test_show_configfile_flag_with_other_args():


### PR DESCRIPTION
Passing `--show-config-file` has the code find the config file, print it, and exit.  There are unit tests that handle the various cases in this operation.

Secondly, I wanted `--show-config-file` flag to not need the other parsers to run before being considered.  So the overall parsing logic is this:

1.  If `--show-config-file` is passed along with `--help`/`-h`, the latter wins out.  Ignore the former and allow `--help` to do its thing.
2. If `--show-config-file` is passed by itself or with any other flag besides `--help`/`-h`, `--show-config-file` wins.  Try to print the config file and exit.
3. If `--show-config-file` is not passed, proceed as normal.

I added some unit tests to test the logic as well. 