### PR TITLE
Redo logic of `ferry-cli` with no arguments given

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -518,6 +518,10 @@ def main() -> None:
         )
 
     ferry_cli = FerryCLI(config_path=config_path)
+    if _help_called_flag:
+        ferry_cli.get_arg_parser().print_help()
+        sys.exit(0)
+
     try:
         auth_args, other_args = get_auth_args()
         if not other_args:

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -471,16 +471,26 @@ def handle_no_args(_config_path: Optional[pathlib.Path]) -> bool:
     """
     Handles the case when no arguments are provided to the CLI.
     """
+    write_config_file = ""
+    would_overwrite = False
     if (_config_path is not None) and (_config_path.exists()):
-        overwrite = input(
+        write_config_file = input(
             f"Configuration file already exists at {_config_path}. Are you sure you want to overwrite it (Y/[n])?  "
         )
-        if overwrite != "Y":
-            FerryCLI(config_path=None).get_arg_parser().print_help()
-            print("Exiting without overwriting configuration file.")
-            sys.exit(0)
+        would_overwrite = True
+    else:
+        write_config_file = input(
+            "Would you like to enter interactive mode to write the configuration file for ferry-cli to use in the future (Y/[n])? "
+        )
+
+    if write_config_file != "Y":
+        FerryCLI(config_path=None).get_arg_parser().print_help()
+        print("Exiting without writing configuration file.")
+        sys.exit(0)
+
+    write_rewrite = "rewrite" if would_overwrite else "write"
     print(
-        "Will launch interactive mode to rewrite configuration file.  If this was a mistake, just press Ctrl+C to exit."
+        f"Will launch interactive mode to {write_rewrite} configuration file.  If this was a mistake, just press Ctrl+C to exit."
     )
     write_config_file_with_user_values()
     sys.exit(0)

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -51,13 +51,12 @@ class FerryCLI:
         self.parser: Optional["FerryParser"] = None
 
         if config_path is None:
-            self.get_arg_parser().print_help()
             print(
-                'Error: A configuration file is required to run the Ferry CLI. Please run "ferry-cli" to generate one interactively.'
+                'A configuration file is required to run the Ferry CLI. Please run "ferry-cli" to generate one interactively if one does not already exist.'
             )
-        else:
-            self.config_path = config_path
+            return
 
+        self.config_path = config_path
         self.configs = self.__parse_config_file()
         self.base_url = self._sanitize_base_url(self.base_url)
         self.dev_url = self._sanitize_base_url(self.dev_url)
@@ -468,18 +467,18 @@ def help_called(args: List[str]) -> bool:
     return "--help" in args or "-h" in args
 
 
-def handle_no_args(_config_path: Optional[pathlib.Path]) -> None:
+def handle_no_args(_config_path: Optional[pathlib.Path]) -> bool:
     """
     Handles the case when no arguments are provided to the CLI.
     """
     if (_config_path is not None) and (_config_path.exists()):
         overwrite = input(
-            "Configuration file already exists. Are you sure you want to overwrite it (Y/[n])?  "
+            f"Configuration file already exists at {_config_path}. Are you sure you want to overwrite it (Y/[n])?  "
         )
         if overwrite != "Y":
+            FerryCLI(config_path=None).get_arg_parser().print_help()
             print("Exiting without overwriting configuration file.")
             sys.exit(0)
-
     print(
         "Will launch interactive mode to rewrite configuration file.  If this was a mistake, just press Ctrl+C to exit."
     )

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -471,26 +471,19 @@ def handle_no_args(_config_path: Optional[pathlib.Path]) -> bool:
     """
     Handles the case when no arguments are provided to the CLI.
     """
-    write_config_file = ""
-    would_overwrite = False
+    write_configfile_prompt = "Would you like to enter interactive mode to write the configuration file for ferry-cli to use in the future (Y/[n])? "
     if (_config_path is not None) and (_config_path.exists()):
-        write_config_file = input(
-            f"Configuration file already exists at {_config_path}. Are you sure you want to overwrite it (Y/[n])?  "
-        )
-        would_overwrite = True
-    else:
-        write_config_file = input(
-            "Would you like to enter interactive mode to write the configuration file for ferry-cli to use in the future (Y/[n])? "
-        )
+        write_configfile_prompt = f"Configuration file already exists at {_config_path}. Are you sure you want to overwrite it (Y/[n])?  "
+
+    write_config_file = input(write_configfile_prompt)
 
     if write_config_file != "Y":
         FerryCLI(config_path=None).get_arg_parser().print_help()
         print("Exiting without writing configuration file.")
         sys.exit(0)
 
-    write_rewrite = "rewrite" if would_overwrite else "write"
     print(
-        f"Will launch interactive mode to {write_rewrite} configuration file.  If this was a mistake, just press Ctrl+C to exit."
+        "Will launch interactive mode to write configuration file.  If this was a mistake, just press Ctrl+C to exit."
     )
     write_config_file_with_user_values()
     sys.exit(0)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -193,14 +193,30 @@ def test_help_called():
 
 
 @pytest.mark.parametrize(
-    "user_input, expected_stdout_after_prompt",
+    "expected_stdout_before_prompt, user_input, expected_stdout_after_prompt",
     [
-        ("n", "Exiting without overwriting configuration file."),
-        ("\n", "Exiting without overwriting configuration file."),
-        ("y", "Exiting without overwriting configuration file."),
         (
+            "Configuration file already exists at",
+            "n",
+            ["usage:", "Exiting without overwriting configuration file."],
+        ),
+        (
+            "Configuration file already exists at",
+            "\n",
+            ["usage:", "Exiting without overwriting configuration file."],
+        ),
+        (
+            "Configuration file already exists at",
+            "y",
+            ["usage:", "Exiting without overwriting configuration file."],
+        ),
+        (
+            "Configuration file already exists at",
             "Y",
-            "Will launch interactive mode to rewrite configuration file.  If this was a mistake, just press Ctrl+C to exit.\nMocked write_config_file",
+            [
+                "Will launch interactive mode to rewrite configuration file.  If this was a mistake, just press Ctrl+C to exit",
+                "Mocked write_config_file",
+            ],
         ),
     ],
 )
@@ -212,6 +228,7 @@ def test_handle_no_args_configfile_exists_Y(
     capsys,
     inject_fake_stdin,
     write_and_set_fake_config_file,
+    expected_stdout_before_prompt,
     user_input,
     expected_stdout_after_prompt,
 ):
@@ -222,11 +239,9 @@ def test_handle_no_args_configfile_exists_Y(
         _main.handle_no_args(config_file)
 
     captured = capsys.readouterr()
-    assert (
-        "Configuration file already exists. Are you sure you want to overwrite it (Y/[n])?  "
-        in captured.out
-    )
+    assert expected_stdout_before_prompt in captured.out
+    for elt in expected_stdout_after_prompt:
+        assert elt in captured.out
 
-    assert expected_stdout_after_prompt in captured.out
     assert pytest_wrapped_e.type == SystemExit
     assert pytest_wrapped_e.value.code == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -217,7 +217,7 @@ def test_help_called():
             "Configuration file already exists at",
             "Y",
             [
-                "Will launch interactive mode to rewrite configuration file.  If this was a mistake, just press Ctrl+C to exit",
+                "Will launch interactive mode to write configuration file.  If this was a mistake, just press Ctrl+C to exit",
                 "Mocked write_config_file",
             ],
         ),


### PR DESCRIPTION
Closes #85 

New logic (italics are the new behavior):

1.  Config file doesn't exist:  _User asked if they want to create config file.  If yes, enter interactive mode.  If no, print help text and exit_
2. Config file does exist:  User asked if they want to overwrite config file.  If yes, enter interactive mode.  _If no, print help text and exit_.

