### PR TITLE
shebang shebang, shemove shemove

### DIFF
--- a/bin/ferry-cli
+++ b/bin/ferry-cli
@@ -1,4 +1,4 @@
-#!/usr/bin/python3 -I
+#!/usr/bin/env python3
 # pylint: disable=invalid-name,wrong-import-position
 import os
 import sys


### PR DESCRIPTION
Updated shebang for executable to use the python3 interpreter in the current user's environment