### PR TITLE
Add validators to setup, add config template, and require python>=3.8

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include bin/ferry-cli
 include ferry_cli/config/swagger.json
+include ferry_cli/config/config.ini

--- a/setup.py
+++ b/setup.py
@@ -33,19 +33,23 @@ setup(
             "ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py",
         ],
         "safeguards": ["ferry_cli/safeguards/dcs.py"],
-        "config": ["ferry_cli/config/swagger.json"],
+        "config": [
+            "ferry_cli/config/swagger.json",
+            "ferry_cli/config/config.ini",
+        ],
     },
     install_requires=[
         "certifi>=2023.11.17",
         "charset-normalizer>=3.3.2",
         "idna>=3.4",
         "requests>=2.31.0",
+        "validators >= 0.22.0",
         "urllib3>=2.1.0",
     ],
     classifiers=[
         "Programming Language :: Python :: 3.6.8+",
         "Operating System :: OS Independent",
     ],
-    python_requires=">=3.6",
+    python_requires=">=3.8",
     scripts=["bin/ferry-cli"],
 )

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
         "charset-normalizer>=3.3.2",
         "idna>=3.4",
         "requests>=2.31.0",
-        "validators >= 0.22.0",
+        "validators>=0.22.0",
         "urllib3>=2.1.0",
     ],
     classifiers=[


### PR DESCRIPTION
In getting ready for a demo, we found two bugs in the setup.py file:

1.  The `validators` library wasn't installed by `setup.py`.
2.  The config template, `ferry_cli/config/config.ini`, was also not installed by `setup.py`.  Thus, when the interactive mode tried to read in the template, it couldn't find the file.

Both of these bugs should be fixed now.

Our version of `validators` doesn't support python<3.8, so I also upgraded that in the setup.py.
