### PR TITLE
Fix output

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -300,7 +300,13 @@ class FerryCLI:
 
         debug = debug_level == DebugLevel.DEBUG
         if debug:
-            print(f"Args:  {vars(args)}\n" f"Endpoint Args:  {endpoint_args}")
+            print(f"Debug level: {debug_level}\nDryrun: {dryrun}")
+            print_args = {
+                f"{k}: {v}"
+                for k, v in vars(args).items()
+                if k not in ["debug_level", "dryrun"]  # We're passing these into run()
+            }
+            print(f"Args: {print_args} \n" f"Endpoint Args:  {endpoint_args}")
             print(f"Using FERRY base url: {self.base_url}")
 
         if not self.ferry_api:

--- a/ferry_cli/helpers/api.py
+++ b/ferry_cli/helpers/api.py
@@ -5,7 +5,7 @@ from typing import Any, Dict
 import requests  # pylint: disable=import-error
 
 try:
-    from ferry_cli.helpers.auth import Auth
+    from ferry_cli.helpers.auth import Auth, DebugLevel
     from ferry_cli.config import CONFIG_DIR
 except ImportError:
     from helpers.auth import Auth  # type: ignore
@@ -19,21 +19,19 @@ class FerryAPI:
         self: "FerryAPI",
         base_url: str,
         authorizer: Auth = Auth(),
-        quiet: bool = False,
-        debug: bool = False,
+        debug_level: DebugLevel = DebugLevel.NORMAL,
         dryrun: bool = False,
     ):
         """
         Parameters:
             base_url (str):  The root URL from which all FERRY API URLs are constructed
             authorizer (Callable[[requests.Session, requests.Session]): A function that prepares the requests session by adding any necessary auth data
-            quiet (bool):  Whether or not output should be suppressed
+            debug_level (DebugLevel): Level of debugging.  Can be DebugLevel.QUIET, DebugLevel.NORMAL, or DebugLevel.DEBUG
             dryrun (bool): Whether or not this is a test run.  If True, the intended URL will be printed, but the HTTP request will not be made
         """
         self.base_url = base_url
         self.authorizer = authorizer
-        self.quiet = quiet
-        self.debug = debug
+        self.debug_level = debug_level
         self.dryrun = dryrun
 
     # pylint: disable=dangerous-default-value,too-many-arguments
@@ -51,7 +49,9 @@ class FerryAPI:
             print(f"\nWould call endpoint: {self.base_url}{endpoint}")
             return None
 
-        if not self.quiet and self.debug:
+        debug = self.debug_level == DebugLevel.DEBUG
+
+        if debug:
             print(f"\nCalling Endpoint: {self.base_url}{endpoint}")
 
         _session = requests.Session()
@@ -77,7 +77,7 @@ class FerryAPI:
                 )
             else:
                 raise ValueError("Unsupported HTTP method.")
-            if not self.quiet and self.debug:
+            if debug:
                 print(f"Called Endpoint: {response.request.url}")
             output = response.json()
 

--- a/ferry_cli/helpers/api.py
+++ b/ferry_cli/helpers/api.py
@@ -12,13 +12,15 @@ except ImportError:
     from config import CONFIG_DIR  # type: ignore
 
 
-# pylint: disable=unused-argument,pointless-statement
+# pylint: disable=unused-argument,pointless-statement,too-many-arguments
 class FerryAPI:
+    # pylint: disable=too-many-arguments
     def __init__(
         self: "FerryAPI",
         base_url: str,
         authorizer: Auth = Auth(),
         quiet: bool = False,
+        debug: bool = False,
         dryrun: bool = False,
     ):
         """
@@ -31,6 +33,7 @@ class FerryAPI:
         self.base_url = base_url
         self.authorizer = authorizer
         self.quiet = quiet
+        self.debug = debug
         self.dryrun = dryrun
 
     # pylint: disable=dangerous-default-value,too-many-arguments
@@ -48,7 +51,7 @@ class FerryAPI:
             print(f"\nWould call endpoint: {self.base_url}{endpoint}")
             return None
 
-        if not self.quiet:
+        if not self.quiet and self.debug:
             print(f"\nCalling Endpoint: {self.base_url}{endpoint}")
 
         _session = requests.Session()
@@ -74,7 +77,7 @@ class FerryAPI:
                 )
             else:
                 raise ValueError("Unsupported HTTP method.")
-            if not self.quiet:
+            if not self.quiet and self.debug:
                 print(f"Called Endpoint: {response.request.url}")
             output = response.json()
 

--- a/ferry_cli/helpers/auth.py
+++ b/ferry_cli/helpers/auth.py
@@ -172,13 +172,6 @@ def get_auth_parser() -> "FerryParser":
     auth_parser.add_argument(
         "--ca-path", default=DEFAULT_CA_DIR, help="Certificate authority path"
     )
-    auth_parser.add_argument(
-        "-d",
-        "--debug",
-        action="store_true",
-        default=False,
-        help="Turn on debugging",
-    )
     output_group = auth_parser.add_mutually_exclusive_group(required=False)
     output_group.add_argument(
         "--dryrun",
@@ -186,7 +179,7 @@ def get_auth_parser() -> "FerryParser":
         default=False,
         help="Populate the API call(s) but don't actually run them",
     )
-    auth_parser.add_argument(
+    output_group.add_argument(
         "-d",
         "--debug",
         action="store_true",

--- a/ferry_cli/helpers/auth.py
+++ b/ferry_cli/helpers/auth.py
@@ -109,7 +109,7 @@ class AuthToken(Auth):
             )
         except FileNotFoundError:
             raise FileNotFoundError(  # pylint: disable=raise-missing-from
-                f"Bearer token file not found. Please verify that you have a valid token in the specified, or default path: /tmp/{default_token_file_name()}, or run 'htgettoken -i htvaultprod.fnal.gov -i fermilab'"
+                f"Bearer token file not found. Please verify that you have a valid token in the specified, or default path: /tmp/{default_token_file_name()}, or run 'htgettoken -a htvaultprod.fnal.gov -i fermilab'"
             )
 
     def __call__(self: "AuthToken", s: requests.Session) -> requests.Session:

--- a/ferry_cli/helpers/auth.py
+++ b/ferry_cli/helpers/auth.py
@@ -103,7 +103,7 @@ class AuthToken(Auth):
         self.debug = debug
         try:
             self.token_string = (
-                get_default_token_string()
+                get_default_token_string(debug)
                 if token_path is None
                 else read_in_token(token_path)
             )
@@ -186,6 +186,13 @@ def get_auth_parser() -> "FerryParser":
         default=False,
         help="Populate the API call(s) but don't actually run them",
     )
+    auth_parser.add_argument(
+        "-d",
+        "--debug",
+        action="store_true",
+        default=False,
+        help="Turn on debugging",
+    )
     output_group.add_argument(
         "-q", "--quiet", action="store_true", default=False, help="Hide output"
     )
@@ -214,11 +221,11 @@ def get_auth_parser() -> "FerryParser":
 def set_auth_from_args(args: Namespace) -> Auth:
     """Set the auth class based on the given arguments"""
     if args.auth_method == "token":
-        if not args.quiet:
+        if not args.quiet and args.debug:
             print("\nUsing token auth")
         return AuthToken(args.token_path, args.debug)
     elif args.auth_method in ["cert", "certificate"]:
-        if not args.quiet:
+        if not args.quiet and args.debug:
             print("\nUsing cert auth")
         return AuthCert(args.cert_path, args.ca_path, args.debug)
     else:

--- a/ferry_cli/helpers/supported_workflows/CloneResource.py
+++ b/ferry_cli/helpers/supported_workflows/CloneResource.py
@@ -4,6 +4,7 @@ from typing import Any, Dict
 
 try:
     from ferry_cli.helpers.api import FerryAPI
+    from ferry_cli.helpers.auth import DebugLevel
     from ferry_cli.helpers.workflows import Workflow
 except ImportError:
     from helpers.api import FerryAPI  # type: ignore
@@ -103,19 +104,19 @@ class CloneResource(Workflow):
                     "Dryrun: Since no API was actually run, we cannot simulate adding users from the cloned resource to the new resource"
                 )
             else:
-                if not api.quiet:
+                if api.debug_level != DebugLevel.QUIET:
                     print(f"Received response, searching for resource: {args['clone']}")
             resources = [resource for resource in group_json if resource.get("resourcename", "") == args["clone"]]  # type: ignore
             if resources:
                 # Add each user from the original resource into the new resource with the same configurations
                 for resource in resources:
-                    if not api.quiet:
+                    if api.debug_level != DebugLevel.QUIET:
                         print("Found Resources")
                         print(resource)
                     for user in resource.get("users", []):
                         user_access_data = dict(user)
                         user_access_data["resourcename"] = args["new_resource"]
-                        if not api.quiet:
+                        if api.debug_level != DebugLevel.QUIET:
                             print(
                                 f"Updating user access to {args['new_resource']} for {user['username']}"
                             )
@@ -129,7 +130,7 @@ class CloneResource(Workflow):
                                 params=user_access_data,
                             ),
                         )
-            if not api.quiet:
+            if api.debug_level != DebugLevel.QUIET:
                 print(
                     f"Resource '{args['clone']}' has been successful cloned as '{args['new_resource']}'"
                 )

--- a/ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py
+++ b/ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, List
 
 try:
     from ferry_cli.helpers.workflows import Workflow
+    from ferry_cli.helpers.auth import DebugLevel
 except ImportError:
     from helpers.workflows import Workflow  # type: ignore
 
@@ -26,7 +27,7 @@ class GetFilteredGroupInfo(Workflow):
         group_json = self.verify_output(api, api.call_endpoint("getAllGroups"))
         if api.dryrun:
             return []
-        if not api.quiet:
+        if api.debug_level != DebugLevel.QUIET:
             print("Received successful response")
             print(f"Filtering by groupname: '{args['groupname']}'")
         group_info = [

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
         "urllib3>=2.1.0",
     ],
     classifiers=[
-        "Programming Language :: Python :: 3.6.8+",
+        "Programming Language :: Python :: 3.8+",
         "Operating System :: OS Independent",
     ],
     python_requires=">=3.8",


### PR DESCRIPTION
After the presentation @cathulhu made today, we decided to fix some of the output.  The idea is now this:

1.  With no flags, we JUST output the JSON gotten back from FERRY to stdout.
2. With --quiet, nothing gets output
3. With --debug, we output everything we used to output in normal mode and debug mode.

This allows us to chain commands in normal mode, like:

```
$ ferry-cli -e getUserInfo --username myuser | jq | jq '.ferry_output.uid'
```

and pull out the UID in one go.

### Tests run:

1. Unit tests
2. No Flags:
```
$ ferry-cli -e ping
{
    "ferry_status": "success",
    "ferry_error": [],
    "ferry_output": {
        "builddate": "20241011.194140",
        "releaseversion": "v2.3.2-89-gb4f35c0",
        "server": "production"
    },
    "request_url": "REDACTED"
}
```
3. --debug flag:
```
$ ferry-cli --debug  -e ping

Using token auth
XDG_RUNTIME_DIR is set:  using file contents of REDACTED
Args:  {'auth_method': 'token', 'token_path': None, 'cert_path': None, 'ca_path': '/etc/grid-security/certificates', 'dryrun': False, 'debug_level': <DebugLevel.NORMAL: 1>, 'update': False, 'support_email': None, 'version': None, 'output': None, 'filter': None, 'list_endpoints': None, 'list_workflows': None, 'endpoint_params': None, 'workflow_params': None, 'endpoint': 'ping', 'workflow': None, 'show_config_file': False}
Endpoint Args:  []
Using FERRY base url: REDACTED

Calling Endpoint: REDACTED

Adding Authorization header: "Bearer XXXXXXXXXXX" to HTTP session
Actual Token string redacted

Called Endpoint: REDACTED
Response: {
    "ferry_status": "success",
    "ferry_error": [],
    "ferry_output": {
        "builddate": "20241011.194140",
        "releaseversion": "v2.3.2-89-gb4f35c0",
        "server": "production"
    },
    "request_url": "REDACTED"
}
```
4.  --quiet flag:
```
$ ferry-cli --quiet  -e ping
$
```

This also works with workflows too.

One outstanding issue - I'm not sure why in the "--debug" mode, `args.debug_level` shows up as `DebugLevel.NORMAL`.  That's the default, but `--debug` should be overriding it, and the behavior of the testing shows that that's what happens.  I don't consider that a show-stopper, but something we should definitely look at in the near future.