### PR TITLE
Fixed import helpers.auth.DebugLevel bug

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -30,6 +30,7 @@ except ImportError:
     from helpers.api import FerryAPI  # type: ignore
     from helpers.auth import (  # type: ignore
         Auth,
+        DebugLevel,
         get_auth_args,
         set_auth_from_args,
         get_auth_parser,

--- a/ferry_cli/helpers/api.py
+++ b/ferry_cli/helpers/api.py
@@ -8,7 +8,7 @@ try:
     from ferry_cli.helpers.auth import Auth, DebugLevel
     from ferry_cli.config import CONFIG_DIR
 except ImportError:
-    from helpers.auth import Auth  # type: ignore
+    from helpers.auth import Auth, DebugLevel  # type: ignore
     from config import CONFIG_DIR  # type: ignore
 
 

--- a/ferry_cli/helpers/supported_workflows/CloneResource.py
+++ b/ferry_cli/helpers/supported_workflows/CloneResource.py
@@ -8,6 +8,7 @@ try:
     from ferry_cli.helpers.workflows import Workflow
 except ImportError:
     from helpers.api import FerryAPI  # type: ignore
+    from helpers.auth import DebugLevel  # type: ignore
     from helpers.workflows import Workflow  # type: ignore
 
 

--- a/ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py
+++ b/ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py
@@ -2,9 +2,10 @@
 from typing import Any, Dict, List
 
 try:
-    from ferry_cli.helpers.workflows import Workflow
     from ferry_cli.helpers.auth import DebugLevel
+    from ferry_cli.helpers.workflows import Workflow
 except ImportError:
+    from helpers.auth import DebugLevel  # type: ignore
     from helpers.workflows import Workflow  # type: ignore
 
 


### PR DESCRIPTION
TL; DR:  Add appropriate imports of `helpers.auth.DebugLevel` class to fallback clauses in imports where needed.

Tested with git-cloned "install", and pip installation of code.  All unit tests pass.

### Longer explanation

@cathulhu was working on another issue in this project, and found that if she hadn't `pip install`ed this repository, but rather `git clone`d it, she would see the following error:

```
Traceback (most recent call last):
  File "/home/sbhat/Ferry-CLI/ferry_cli/__main__.py", line 19, in <module>
    from ferry_cli.helpers.api import FerryAPI
ModuleNotFoundError: No module named 'ferry_cli'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/sbhat/Ferry-CLI/ferry_cli/__main__.py", line 33, in <module>
    from helpers.api import FerryAPI  # type: ignore
  File "/home/sbhat/Ferry-CLI/ferry_cli/helpers/api.py", line 16, in <module>
    class FerryAPI:
  File "/home/sbhat/Ferry-CLI/ferry_cli/helpers/api.py", line 22, in FerryAPI
    debug_level: DebugLevel = DebugLevel.NORMAL,
NameError: name 'DebugLevel' is not defined
```

This error shows up when we try to run `ferry_cli/__main__.py` directly, but not if we run `bin/ferry-cli`, which imports the former. The error handling here is correct - if `ferry_cli` is not `pip` installed, then it will fail the `from ferry_cli.blahblah` imports, and will fall back to local imports like `from helpers.blahblah`.  

This particular import, `from helpers.api import FerryAPI`, was failing because in #93, we didn't add imports of `helpers.auth.DebugLevel` to the fallback import statements in all of the files that import that class.  We didn't catch it before, because in `pip` installations, this wasn't an issue; only if you downloaded the source code and try to run from there.

That issue is fixed here.