### PR TITLE
Reordered checking for --update flag and checking for no other args

### DIFF
--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -545,6 +545,7 @@ def handle_no_args(_config_path: Optional[pathlib.Path]) -> bool:
     sys.exit(0)
 
 
+# pylint: disable=too-many-branches
 def main() -> None:
     _config_path = config.get_configfile_path()
     if len(sys.argv) == 1:
@@ -580,9 +581,6 @@ def main() -> None:
 
     try:
         auth_args, other_args = get_auth_args()
-        if not other_args:
-            ferry_cli.get_arg_parser().print_help()
-            sys.exit(0)
         ferry_cli.authorizer = set_auth_from_args(auth_args)
         if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
             if auth_args.debug_level != DebugLevel.QUIET:
@@ -595,6 +593,14 @@ def main() -> None:
             ferry_cli.ferry_api.get_latest_swagger_file()
             if auth_args.debug_level != DebugLevel.QUIET:
                 print("Successfully stored latest swagger file.\n")
+            if not other_args:
+                if auth_args.debug_level != DebugLevel.QUIET:
+                    print("No more arguments provided. Exiting.")
+                sys.exit(0)
+
+        if not other_args:
+            ferry_cli.get_arg_parser().print_help()
+            sys.exit(1)
 
         ferry_cli.endpoints = ferry_cli.generate_endpoints()
         ferry_cli.run(

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -43,14 +43,44 @@ except ImportError:
 
 class FerryCLI:
     # pylint: disable=too-many-instance-attributes
-    def __init__(self: "FerryCLI", config_path: Optional[pathlib.Path]) -> None:
+    def __init__(
+        self: "FerryCLI",
+        config_path: Optional[pathlib.Path] = None,
+        authorizer: Auth = Auth(),
+        print_help: bool = False,
+    ) -> None:
+        """
+        Initializes the FerryCLI instance.
+
+        Args:
+            config_path (Optional[pathlib.Path]): The path to the configuration file. If None,
+                a message will be printed indicating that a configuration file is required.
+            authorizer (Auth): An instance of the Auth class used for authorization. Defaults to a dummy Auth instance.
+            print_help (bool): If True, prints the help message for the CLI and does not run any setup of the FerryCLI class. Defaults to False.
+
+        Class Attributes:
+            base_url (str): The base URL for the Ferry API.
+            dev_url (str): The development URL for the Ferry API.
+            safeguards (SafeguardsDCS): An instance of SafeguardsDCS for managing safeguards.
+            endpoints (Dict[str, Any]): A dictionary to store API endpoints.
+            ferry_api (Optional[FerryAPI]): An instance of the FerryAPI class, initialized later.
+            parser (Optional[FerryParser]): An instance of the FerryParser class, initialized later.
+            config_path (pathlib.Path): The path to the configuration file.
+            configs (dict): Parsed configuration data from the configuration file.
+            authorizer (Auth): The authorizer instance used for API authentication.
+
+        Raises:
+            ValueError: If the configuration file does not have a base_url specified.
+        """
         self.base_url: str
         self.dev_url: str
         self.safeguards = SafeguardsDCS()
         self.endpoints: Dict[str, Any] = {}
-        self.authorizer: Optional["Auth"] = None
         self.ferry_api: Optional["FerryAPI"] = None
         self.parser: Optional["FerryParser"] = None
+        if print_help:
+            self.get_arg_parser().print_help()
+            return
         if config_path is None:
             print(
                 'A configuration file is required to run the Ferry CLI. Please run "ferry-cli" to generate one interactively if one does not already exist.'
@@ -59,6 +89,7 @@ class FerryCLI:
 
         self.config_path = config_path
         self.configs = self.__parse_config_file()
+        self.authorizer = authorizer
         self.base_url = self._sanitize_base_url(self.base_url)
         self.dev_url = self._sanitize_base_url(self.dev_url)
 
@@ -312,7 +343,10 @@ class FerryCLI:
 
         if not self.ferry_api:
             self.ferry_api = FerryAPI(
-                base_url=self.base_url, authorizer=self.authorizer, debug_level=debug_level, dryrun=dryrun  # type: ignore
+                base_url=self.base_url,
+                authorizer=self.authorizer,
+                debug_level=debug_level,
+                dryrun=dryrun,
             )
 
         if args.endpoint:
@@ -534,7 +568,7 @@ def handle_no_args(_config_path: Optional[pathlib.Path]) -> bool:
     write_config_file = input(write_configfile_prompt)
 
     if write_config_file != "Y":
-        FerryCLI(config_path=None).get_arg_parser().print_help()
+        FerryCLI(print_help=True)
         print("Exiting without writing configuration file.")
         sys.exit(0)
 
@@ -574,14 +608,15 @@ def main() -> None:
             "arguments to generate a new configuration file interactively."
         )
 
-    ferry_cli = FerryCLI(config_path=config_path)
     if _help_called_flag:
-        ferry_cli.get_arg_parser().print_help()
+        FerryCLI(print_help=True)
         sys.exit(0)
 
     try:
         auth_args, other_args = get_auth_args()
-        ferry_cli.authorizer = set_auth_from_args(auth_args)
+        ferry_cli = FerryCLI(
+            config_path=config_path, authorizer=set_auth_from_args(auth_args)
+        )
         if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
             if auth_args.debug_level != DebugLevel.QUIET:
                 print("Fetching latest swagger file...")

--- a/ferry_cli/helpers/auth.py
+++ b/ferry_cli/helpers/auth.py
@@ -91,7 +91,9 @@ class Auth(ABC):
     """This is the base class on which all Auth classes should build"""
 
     def __call__(self: "Auth", s: requests.Session) -> requests.Session:
-        return s
+        raise NotImplementedError(
+            "Must use a subclass of Auth with __call__ method defined"
+        )
 
 
 class AuthToken(Auth):


### PR DESCRIPTION
Reordered pre-FerryCLI steps so that they are:


1. Parse our auth args
2. Set up the credential
3. Check for --update flag
4. Check to see if we have other args and DON'T have the --update flag set


Tests are in the comments below.