### PR TITLE
"token_subject" should be "tokensubject" for NewCapabilitySet workflow

### DIFF
--- a/ferry_cli/helpers/supported_workflows/NewCapabilitySet.py
+++ b/ferry_cli/helpers/supported_workflows/NewCapabilitySet.py
@@ -71,6 +71,14 @@ class NewCapabilitySet(Workflow):
                 "type": "string",
                 "required": False,
             },
+            {
+                "name": "vault_storage_key",
+                "description": (
+                    'The default will just be setname, but if the intent is to not store this vault storage key in LDAP, set this to the string "none"'
+                ),
+                "type": "string",
+                "required": False,
+            },
         ]
         super().__init__()
 
@@ -244,7 +252,9 @@ class NewCapabilitySet(Workflow):
                 "pattern": args["scopes_pattern"],
             }
             if args.get("token_subject", None) is not None:
-                new_cap_set_params["token_subject"] = args["token_subject"]
+                new_cap_set_params["tokensubject"] = args["token_subject"]
+            if args.get("vault_storage_key", None) is not None:
+                new_cap_set_params["vaultstoragekey"] = args["vault_storage_key"]
 
             self.verify_output(
                 api,

--- a/tests/test_NewCapabilitySet.py
+++ b/tests/test_NewCapabilitySet.py
@@ -65,7 +65,7 @@ from ferry_cli.helpers.supported_workflows.NewCapabilitySet import NewCapability
                 ),
                 (
                     "Would call endpoint: https://example.com/createCapabilitySet with params\n"
-                    + "{'setname': 'testcapabilityset', 'pattern': 'scope1,scope2', 'token_subject': 'none'}"
+                    + "{'setname': 'testcapabilityset', 'pattern': 'scope1,scope2', 'tokensubject': 'none'}"
                 ),
                 (
                     "Would call endpoint: https://example.com/addCapabilitySetToFQAN with params\n"


### PR DESCRIPTION
There was a slight bug in #104, where the workflow key `token_subject` was passed as is to FERRY.  The name of that key should be `tokensubject` when we make the FERRY API call.

I also added a flag for the `vaultstoragekey` key, though it's rarely used.