### PR TITLE
Add --server flag to override server given to ferry-cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,17 @@
+# Build artifacts
+build/
+.vscode/
+__pycache__/
+ferry_cli.egg-info/
+
+# Development artifacts
 result.json
 .venv
 .git
-/tmp/*
-__pycache__
-.make_creds.sh
 swagger.json
 config/swagger.json
+
+# Testing artifacts
+/tmp/*
+.make_creds.sh
 remove

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -621,7 +621,9 @@ def main() -> None:
     try:
         auth_args, other_args = get_auth_args()
         ferry_cli = FerryCLI(
-            config_path=config_path, authorizer=set_auth_from_args(auth_args)
+            config_path=config_path,
+            authorizer=set_auth_from_args(auth_args),
+            base_url=auth_args.server,
         )
         if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
             if auth_args.debug_level != DebugLevel.QUIET:

--- a/ferry_cli/__main__.py
+++ b/ferry_cli/__main__.py
@@ -45,6 +45,7 @@ class FerryCLI:
     # pylint: disable=too-many-instance-attributes
     def __init__(
         self: "FerryCLI",
+        base_url: Optional[str] = None,
         config_path: Optional[pathlib.Path] = None,
         authorizer: Auth = Auth(),
         print_help: bool = False,
@@ -53,6 +54,7 @@ class FerryCLI:
         Initializes the FerryCLI instance.
 
         Args:
+            base_url (Optional[str]): The base URL for the Ferry API, if that should not come from the file specified by config_path.
             config_path (Optional[pathlib.Path]): The path to the configuration file. If None,
                 a message will be printed indicating that a configuration file is required.
             authorizer (Auth): An instance of the Auth class used for authorization. Defaults to a dummy Auth instance.
@@ -90,7 +92,11 @@ class FerryCLI:
         self.config_path = config_path
         self.configs = self.__parse_config_file()
         self.authorizer = authorizer
-        self.base_url = self._sanitize_base_url(self.base_url)
+        self.base_url = (
+            self._sanitize_base_url(self.base_url)
+            if base_url is None
+            else self._sanitize_base_url(base_url)
+        )
         self.dev_url = self._sanitize_base_url(self.dev_url)
 
     def get_arg_parser(self: "FerryCLI") -> FerryParser:

--- a/ferry_cli/helpers/auth.py
+++ b/ferry_cli/helpers/auth.py
@@ -214,6 +214,11 @@ def get_auth_parser() -> "FerryParser":
         action=request_project_info("email"),
     )
     auth_parser.add_argument(
+        "-s",
+        "--server",
+        help="Server URL to use instead of configuration file api.base_url value",
+    )
+    auth_parser.add_argument(
         "--version",
         nargs=0,
         help="Get Ferry CLI version",


### PR DESCRIPTION
Closes #99 

Adds a new flag, `-s/--server`, that allows for users to override the configured `api.base_url` value.  This allows for quick testing of different FERRY instances.

Also added unit tests for both the changed functionality in the `FerryCLI` class, and the overall CLI and new flag.

All unit tests pass, as well as the following check:

```
$ ./bin/ferry-cli --dryrun --server https://fakeserver:12345  -e ping

Would call endpoint: https://fakeserver:12345/ping with params
{}
```