### PR TITLE
Make the swagger.json endpoint configurable

### DIFF
--- a/src/ferry_cli/config/config.ini
+++ b/src/ferry_cli/config/config.ini
@@ -13,13 +13,13 @@ base_url = {base_url}
 # Define an optional dev instance url to be used instead of base_url
 dev_url = {dev_url}
 
-# Define url to your swagger.json
+# Define endpoint to your swagger.json
 # This is the path that we use to download your swagger.json file during setup, and to fetch newer versions.
 # EVERYTHING in this cli is built off of this file
 # We download this file on first use, and is store it in "/path/to/ferry_cli/config/swagger.json"
 # When updating [-u, --update], we fetch a new version of this file and override the existing file.
 #
-# swagger_file_url = "https://sample_swagger_site.com/docs/swagger.json"
+swagger_file_endpoint = docs/swagger.json
 
 
 [authorization]

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -356,6 +356,10 @@ class FerryCLI:
                 authorizer=self.authorizer,
                 debug_level=debug_level,
                 dryrun=dryrun,
+                swagger_endpoint=self.configs.get(
+                    "api", "swagger_file_endpoint", fallback=""
+                ).strip(' "')
+                or None,
             )
 
         if args.endpoint:
@@ -662,9 +666,13 @@ def main() -> None:
             if auth_args.debug_level != DebugLevel.QUIET:
                 print("Fetching latest swagger file...")
             ferry_cli.ferry_api = FerryAPI(
-                ferry_cli.base_url,
-                ferry_cli.authorizer,
-                auth_args.debug_level,
+                base_url=ferry_cli.base_url,
+                authorizer=ferry_cli.authorizer,
+                debug_level=auth_args.debug_level,
+                swagger_endpoint=ferry_cli.configs.get(
+                    "api", "swagger_file_endpoint", fallback=""
+                ).strip(' "')
+                or None,
             )
             ferry_cli.ferry_api.get_latest_swagger_file()
             if auth_args.debug_level != DebugLevel.QUIET:

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -1,8 +1,7 @@
 import json
 import pathlib
 import sys
-import tempfile
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 import requests  # pylint: disable=import-error
 
@@ -24,7 +23,7 @@ class FerryAPI:
         authorizer: Auth = Auth(),
         debug_level: DebugLevel = DebugLevel.NORMAL,
         dryrun: bool = False,
-        swagger_endpoint: str | None = None,
+        swagger_endpoint: Optional[str] = None,
     ):
         """
         Parameters:
@@ -32,7 +31,7 @@ class FerryAPI:
             authorizer (Callable[[requests.Session, requests.Session]): A function that prepares the requests session by adding any necessary auth data
             debug_level (DebugLevel): Level of debugging.  Can be DebugLevel.QUIET, DebugLevel.NORMAL, or DebugLevel.DEBUG
             dryrun (bool): Whether or not this is a test run.  If True, the intended URL will be printed, but the HTTP request will not be made
-            swagger_endpoint: str | None: The API endpoint (after base_url) to obtain the swagger.json file from the FERRY server.  If set to None, will use the default self.SWAGGER_JSON_ENDPOINT_DEFAULT.
+            swagger_endpoint (Optional[str]): The API endpoint (after base_url) to obtain the swagger.json file from the FERRY server.  If set to None, will use the default self.SWAGGER_JSON_ENDPOINT_DEFAULT.
         """
         self.base_url = base_url
         self.authorizer = authorizer
@@ -97,20 +96,21 @@ class FerryAPI:
 
             output["request_url"] = response.request.url
             return output
-        except BaseException as e:
+        except Exception as e:
             # How do we want to handle errors?
             raise e
 
-    # TODO: integration test
-    def get_latest_swagger_file(self: "FerryAPI"):
+    # TODO: integration test  # pylint: disable=fixme
+    def get_latest_swagger_file(self: "FerryAPI") -> None:
         """
-        Gets the latest swagger file from FERRY and set it in the class instance.
-        Will save it in either:
-        1. The directory returned by config.get_configfile_dir(), or
-        2. tempfile.gettempdir(), if (1) doesn't return a valid directory
+        Gets the latest swagger file from FERRY and save it in config.CONFIG_DIR/swagger.json
         """
+        if self.dryrun:
+            print("Dryrun: skipping swagger.json fetching")
+            return
+
         response = self.call_endpoint(self.swagger_endpoint)
-        if not response and not self.dryrun:
+        if not response:
             print("Failed to fetch swagger.json file")
             sys.exit(1)
 
@@ -118,12 +118,9 @@ class FerryAPI:
 
         try:
             swagger_file.parent.mkdir(parents=True, exist_ok=True)
-        except BaseException as e:
-            print(f"Could not create dir {swagger_file.parent}")
-            raise e
+        except Exception as e:
+            print(f"Could not create dir {swagger_file.parent}: {e}")
+            raise
 
         with open(swagger_file, "w") as file:
             file.write(json.dumps(response, indent=4))
-
-        if self.debug_level != DebugLevel.QUIET:
-            print("Successfully stored latest swagger file.\n")

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -1,5 +1,7 @@
 import json
+import pathlib
 import sys
+import tempfile
 from typing import Any, Dict
 
 import requests  # pylint: disable=import-error
@@ -14,6 +16,7 @@ except ImportError:
 
 # pylint: disable=unused-argument,pointless-statement,too-many-arguments
 class FerryAPI:
+    SWAGGER_JSON_ENDPOINT_DEFAULT = "docs/swagger.json"
     # pylint: disable=too-many-arguments
     def __init__(
         self: "FerryAPI",
@@ -21,6 +24,7 @@ class FerryAPI:
         authorizer: Auth = Auth(),
         debug_level: DebugLevel = DebugLevel.NORMAL,
         dryrun: bool = False,
+        swagger_endpoint: str | None = None,
     ):
         """
         Parameters:
@@ -28,11 +32,15 @@ class FerryAPI:
             authorizer (Callable[[requests.Session, requests.Session]): A function that prepares the requests session by adding any necessary auth data
             debug_level (DebugLevel): Level of debugging.  Can be DebugLevel.QUIET, DebugLevel.NORMAL, or DebugLevel.DEBUG
             dryrun (bool): Whether or not this is a test run.  If True, the intended URL will be printed, but the HTTP request will not be made
+            swagger_endpoint: str | None: The API endpoint (after base_url) to obtain the swagger.json file from the FERRY server.  If set to None, will use the default self.SWAGGER_JSON_ENDPOINT_DEFAULT.
         """
         self.base_url = base_url
         self.authorizer = authorizer
         self.debug_level = debug_level
         self.dryrun = dryrun
+        self.swagger_endpoint = (
+            swagger_endpoint if swagger_endpoint else self.SWAGGER_JSON_ENDPOINT_DEFAULT
+        )
 
     # pylint: disable=dangerous-default-value,too-many-arguments
     def call_endpoint(
@@ -93,12 +101,29 @@ class FerryAPI:
             # How do we want to handle errors?
             raise e
 
-    def get_latest_swagger_file(self: "FerryAPI") -> None:
-
-        response = self.call_endpoint("docs/swagger.json")
-        if response:
-            with open(f"{CONFIG_DIR}/swagger.json", "w") as file:
-                file.write(json.dumps(response, indent=4))
-        else:
+    # TODO: integration test
+    def get_latest_swagger_file(self: "FerryAPI"):
+        """
+        Gets the latest swagger file from FERRY and set it in the class instance.
+        Will save it in either:
+        1. The directory returned by config.get_configfile_dir(), or
+        2. tempfile.gettempdir(), if (1) doesn't return a valid directory
+        """
+        response = self.call_endpoint(self.swagger_endpoint)
+        if not response and not self.dryrun:
             print("Failed to fetch swagger.json file")
             sys.exit(1)
+
+        swagger_file = pathlib.Path(CONFIG_DIR) / "swagger.json"
+
+        try:
+            swagger_file.parent.mkdir(parents=True, exist_ok=True)
+        except BaseException as e:
+            print(f"Could not create dir {swagger_file.parent}")
+            raise e
+
+        with open(swagger_file, "w") as file:
+            file.write(json.dumps(response, indent=4))
+
+        if self.debug_level != DebugLevel.QUIET:
+            print("Successfully stored latest swagger file.\n")


### PR DESCRIPTION
Adds a config file entry, `api.swagger_file_endpoint` that allows the user to configure where the swagger API's `swagger.json` file lives.