### PR TITLE
Change default swagger.json endpoint

### DIFF
--- a/src/ferry_cli/config/config.ini
+++ b/src/ferry_cli/config/config.ini
@@ -19,7 +19,7 @@ dev_url = {dev_url}
 # We download this file on first use, and is store it in "/path/to/ferry_cli/config/swagger.json"
 # When updating [-u, --update], we fetch a new version of this file and override the existing file.
 #
-swagger_file_endpoint = docs/swagger.json
+swagger_file_endpoint = swagger/swagger.json
 
 
 [authorization]

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -15,7 +15,7 @@ except ImportError:
 
 # pylint: disable=unused-argument,pointless-statement,too-many-arguments
 class FerryAPI:
-    SWAGGER_JSON_ENDPOINT_DEFAULT = "docs/swagger.json"
+    SWAGGER_JSON_ENDPOINT_DEFAULT = "swagger/swagger.json"
     # pylint: disable=too-many-arguments
     def __init__(
         self: "FerryAPI",
@@ -103,7 +103,7 @@ class FerryAPI:
     # TODO: integration test  # pylint: disable=fixme
     def get_latest_swagger_file(self: "FerryAPI") -> None:
         """
-        Gets the latest swagger file from FERRY and save it in config.CONFIG_DIR/swagger.json
+        Gets the latest swagger file from FERRY and saves it in config.CONFIG_DIR/swagger.json
         """
         if self.dryrun:
             print("Dryrun: skipping swagger.json fetching")


### PR DESCRIPTION
This is for the upcoming FERRY change announced by the FERRY operator.  Given #117, users will still be able to set their own swagger.json endpoint.