### PR TITLE
swagger.json file should be saved to user's local config dir, not next to the code

### DIFF
--- a/.github/workflows/Ferry-CLI.yml
+++ b/.github/workflows/Ferry-CLI.yml
@@ -9,7 +9,7 @@ on:
 
 
 jobs:
-  build:
+  pre_commit:
     runs-on: ubuntu-latest
 
     steps:
@@ -18,22 +18,30 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: 3.9
-    - name: Install dependencies
+    - name: Upgrade pip and install dependencies
       run: |
         python3 -m pip install --upgrade pip
         python3 -m pip install pre-commit
         python3 -m pip install pytest
-        python3 -m pip install flake8
         pre-commit install
-    #- name: lint python with flake8;
-      # can adjust flake8 parameters see: https://flake8.pycqa.org/en/latest/user/error-codes.html
-      #run: |
-        #flake8 . --count --show-source --statistics
-    - name: run pre-commit
+    - name: Run pre-commit
       run: pre-commit run --all-files
-    - name: editable install
+  test_editable_install:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: setup Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: 3.9
+    - name: Upgrade pip
+      run: python3 -m pip install --upgrade pip
+    - name: Install pytest
+      run: python3 -m pip install pytest
+    - name: Editable install
       run: python3 -m pip install -e .
-    - name: run unit tests only
+    - name: Run unit tests only
       run: |
         pytest -m unit
     # upon some condition we can run unit and integration tests

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,6 +10,8 @@ repos:
     hooks:
       - id: pylint
         args: [--rcfile=.pylintrc]
+        additional_dependencies:
+        - validators
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
       - id: pylint
         args: [--rcfile=.pylintrc]
         additional_dependencies:
-        - validators
+          - validators
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:
@@ -23,5 +23,5 @@ repos:
 -   repo: https://github.com/psf/black
     rev: 22.8.0
     hooks:
-    -   id: black
+    - id: black
 exclude: ^.spack

--- a/src/ferry_cli/config/config.py
+++ b/src/ferry_cli/config/config.py
@@ -7,7 +7,7 @@ try:
 except ImportError:
     from config import CONFIG_DIR  # type: ignore
 
-__config_path_post_basedir = pathlib.Path("ferry_cli/config.ini")
+__config_path_basename = pathlib.Path("config.ini")
 
 
 def get_configfile_path() -> Optional[pathlib.Path]:
@@ -24,32 +24,52 @@ def get_configfile_path() -> Optional[pathlib.Path]:
     That should be ascertained by checking the return value against None, and then
     using the pathlib.Path.exists() method
     """
+    configfile_dir = get_configfile_dir()
+    return (
+        configfile_dir / __config_path_basename if configfile_dir is not None else None
+    )
+
+
+def get_configfile_dir() -> Optional[pathlib.Path]:
+    """
+    Return the directory where config files should go. If $XDG_CONFIG_HOME is set,
+    its value is used as the root for the config file path.  Otherwise,
+    $HOME/.config is used.  If for some reason $HOME is not set,
+    this function will return None.
+
+    Equivalent to the shell call
+    echo ${XDG_CONFIG_HOME:-HOME/.config}/ferry_cli
+
+    Note that this call does NOT guarantee that the directory actually exists at the returned path.
+    That should be ascertained by checking the return value against None, and then
+    using the pathlib.Path.exists() method
+    """
 
     # TODO:  Once SL7 EOL has passed, change these into assignment expressions. # pylint: disable=fixme
     # e.g. if (xdg_path := _get_configfile_path_xdg_config_home()): return xdg_path
-    xdg_path = _get_configfile_path_xdg_config_home()
-    if xdg_path:
-        return xdg_path
+    xdg_dir = _get_configfile_dir_xdg_config_home()
+    if xdg_dir:
+        return xdg_dir / "ferry_cli"
 
-    home_path = _get_configfile_path_home()
-    if home_path:
-        return home_path
+    home_dir = _get_configfile_dir_home()
+    if home_dir:
+        return home_dir / "ferry_cli"
 
     return None
 
 
-def _get_configfile_path_xdg_config_home() -> Optional[pathlib.Path]:
-    xdg_config_home_val = os.getenv("XDG_CONFIG_HOME")
-    if not xdg_config_home_val:
-        return None
-    return pathlib.Path(xdg_config_home_val) / __config_path_post_basedir
+def _get_configfile_dir_xdg_config_home() -> Optional[pathlib.Path]:
+    _xdg_config_home_val = os.getenv("XDG_CONFIG_HOME")
+    xdg_config_home_val = _xdg_config_home_val.strip() if _xdg_config_home_val else None
+    return (
+        pathlib.Path(xdg_config_home_val) if xdg_config_home_val is not None else None
+    )
 
 
-def _get_configfile_path_home() -> Optional[pathlib.Path]:
-    home = os.getenv("HOME")
-    if not home:
-        return None
-    return pathlib.Path(home) / ".config" / __config_path_post_basedir
+def _get_configfile_dir_home() -> Optional[pathlib.Path]:
+    _home = os.getenv("HOME")
+    home = _home.strip() if _home else None
+    return pathlib.Path(home) / ".config" if home is not None else None
 
 
 def write_out_configfile(config_values: Dict[str, str]) -> pathlib.Path:

--- a/src/ferry_cli/config/config.py
+++ b/src/ferry_cli/config/config.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 import pathlib
 from typing import Optional, Dict
@@ -105,3 +106,15 @@ def _write_out_configfile_with_template(
 
 def _get_template_path() -> pathlib.Path:
     return pathlib.Path(CONFIG_DIR) / "config.ini"
+
+
+def swagger_filename(
+    base_url: str, swagger_endpoint: str = "swagger/swagger.json"
+) -> str:
+    """
+    Generate hash of endpoint including base_url
+    """
+    hasher = hashlib.sha256()
+    hasher.update(f"{base_url}/{swagger_endpoint}".encode("utf-8"))
+    suffix = hasher.hexdigest()[:16]
+    return f"swagger_{suffix}.json"

--- a/src/ferry_cli/config/config.py
+++ b/src/ferry_cli/config/config.py
@@ -62,15 +62,13 @@ def get_configfile_dir() -> Optional[pathlib.Path]:
 def _get_configfile_dir_xdg_config_home() -> Optional[pathlib.Path]:
     _xdg_config_home_val = os.getenv("XDG_CONFIG_HOME")
     xdg_config_home_val = _xdg_config_home_val.strip() if _xdg_config_home_val else None
-    return (
-        pathlib.Path(xdg_config_home_val) if xdg_config_home_val is not None else None
-    )
+    return pathlib.Path(xdg_config_home_val) if xdg_config_home_val else None
 
 
 def _get_configfile_dir_home() -> Optional[pathlib.Path]:
     _home = os.getenv("HOME")
     home = _home.strip() if _home else None
-    return pathlib.Path(home) / ".config" if home is not None else None
+    return pathlib.Path(home) / ".config" if home else None
 
 
 def write_out_configfile(config_values: Dict[str, str]) -> pathlib.Path:
@@ -115,6 +113,8 @@ def swagger_filename(
     Generate hash of endpoint including base_url
     """
     hasher = hashlib.sha256()
-    hasher.update(f"{base_url}/{swagger_endpoint}".encode("utf-8"))
+    hasher.update(
+        f"{base_url.strip('/')}/{swagger_endpoint.strip('/')}".encode("utf-8")
+    )
     suffix = hasher.hexdigest()[:16]
     return f"swagger_{suffix}.json"

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -293,11 +293,13 @@ class FerryCLI:
 
     def generate_endpoints(self: "FerryCLI") -> Dict[str, FerryParser]:
         endpoints = {}
+        # TODO: Use get_configfile_dir here
         with open(f"{CONFIG_DIR}/swagger.json", "r") as json_file:
 
             api_data = json.load(json_file)
             for path, data in api_data["paths"].items():
                 endpoint = path.replace("/", "")
+                # TODO: Get should be the default method
                 if "get" in data:
                     method = "get"
                 elif "post" in data:

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -160,6 +160,10 @@ class FerryCLI:
             authorizer=self.authorizer,
             debug_level=debug_level,
             dryrun=dryrun,
+            swagger_endpoint=self.configs.get(
+                "api", "swagger_file_endpoint", fallback=""
+            ).strip(' "')
+            or None,
         )
         if update:
             self.ferry_api.get_latest_swagger_file()
@@ -338,7 +342,10 @@ class FerryCLI:
                 elif "put" in data:
                     method = "put"
                 else:  # Default
-                    method = "get"
+                    print(
+                        f"Warning: Unsupported HTTP method(s): {data.keys()}. Skipping endpoint"
+                    )
+                    continue  # Skip unsupported method
 
                 endpoint_parser = FerryParser.create_subparser(
                     endpoint,

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -11,7 +11,6 @@ from urllib.parse import urlsplit, urlunsplit, SplitResult
 
 import validators
 
-# TODO: CLean up these imports
 # pylint: disable=unused-import
 try:
     # Try package import
@@ -26,7 +25,7 @@ try:
     from ferry_cli.helpers.ferry_parser import FerryParser
     from ferry_cli.helpers.supported_workflows import SUPPORTED_WORKFLOWS
     from ferry_cli.safeguards.dcs import SafeguardsDCS
-    from ferry_cli.config import CONFIG_DIR, config
+    from ferry_cli.config import config
 except ImportError:
     # Fallback to direct import
     from helpers.api import FerryAPI  # type: ignore
@@ -40,7 +39,7 @@ except ImportError:
     from helpers.ferry_parser import FerryParser  # type: ignore
     from helpers.supported_workflows import SUPPORTED_WORKFLOWS  # type: ignore
     from safeguards.dcs import SafeguardsDCS  # type: ignore
-    from config import CONFIG_DIR, config  # type: ignore
+    from config import config  # type: ignore
 
 
 class FerryCLI:
@@ -652,9 +651,6 @@ def normalize_endpoint(endpoints: Dict[str, Any], raw: str) -> str:
     return next((ep for ep in endpoints if ep.lower() == normalized.lower()), raw)
 
 
-# TODO: FerryAPI should be the one place that knows about the swagger file. Anything that needs that swagger file should call on the FerryAPI class to either provide or generate the file.
-# The two places that use it are 1) below, when the --update flag is used, and 2) in FerryCLI.generate_endpoints.  The latter should look to see if the FerryAPI class has been instantiated and stored locally, and if not, do that.  Then use FerryAPI.get_latest_swagger_file to get the swagger file.  Perhaps the latter should return a Path to the file.
-
 # pylint: disable=too-many-branches
 def main() -> None:
     _config_path = config.get_configfile_path()
@@ -695,59 +691,11 @@ def main() -> None:
             authorizer=set_auth_from_args(auth_args),
             base_url=auth_args.server,
         )
-        if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
-            if auth_args.debug_level != DebugLevel.QUIET:
-                print("Fetching latest swagger file...")
-            ferry_cli.ferry_api = FerryAPI(
-                base_url=ferry_cli.base_url,
-                authorizer=ferry_cli.authorizer,
-                debug_level=auth_args.debug_level,
-                swagger_endpoint=ferry_cli.configs.get(
-                    "api", "swagger_file_endpoint", fallback=""
-                ).strip(' "')
-                or None,
-            )
-            ferry_cli.ferry_api.get_latest_swagger_file()
-            if auth_args.debug_level != DebugLevel.QUIET:
-                print("Successfully stored latest swagger file.\n")
-            if not other_args:
-                if auth_args.debug_level != DebugLevel.QUIET:
-                    print("No more arguments provided. Exiting.")
-                sys.exit(0)
         ferry_cli.setup_FerryAPI(
             debug_level=auth_args.debug_level,
             dryrun=auth_args.dryrun,
             update=auth_args.update,
         )
-
-        # TODO: Order of operations now:
-        # 1. Make sure we have swagger file
-        # 1a. If we don't have any other args, we know it's a malformed call. Exit.  I don't like this.
-        # 2. Generate endpoints
-        # 3. Run call.
-
-        # TODO: Should be:
-        # 1. Instantiate API -- DONE
-        # . Maybe instantiating API should include update or not - to force update or not. -- DONE
-        # . Make sure we have swagger file inside this instantiation (ferry_cli.setup_api() or something like that?). Generate endpoints should be here too. -- DONE
-        # 3. Check for other args. -- DONE
-        # 4. Run call -- DONE
-
-        # if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
-        #     if auth_args.debug_level != DebugLevel.QUIET:
-        #         print("Fetching latest swagger file...")
-        #     ferry_cli.ferry_api = FerryAPI(
-        #         ferry_cli.base_url,
-        #         ferry_cli.authorizer,
-        #         auth_args.debug_level,
-        #     )
-        #     ferry_cli.ferry_api.get_latest_swagger_file()
-        #     if auth_args.debug_level != DebugLevel.QUIET:
-        #         print("Successfully stored latest swagger file.\n")
-        #     if not other_args:
-        #         if auth_args.debug_level != DebugLevel.QUIET:
-        #             print("No more arguments provided. Exiting.")
-        #         sys.exit(0)
 
         if not other_args:
             ferry_cli.get_arg_parser().print_help()

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -325,14 +325,20 @@ class FerryCLI:
         with open(self.ferry_api.swagger_file, "r") as json_file:
             api_data = json.load(json_file)
             for path, data in api_data["paths"].items():
+                # pylint: disable=fixme
+                # TODO: Note:  This is one thing we may want to fix in the future
+                # Right now, ferry-cli assumes that each endpoint supports only one
+                # HTTP verb. Changing that would probably require a major refactor
+                # isn't necessary at this point.
                 endpoint = path.replace("/", "")
-                # TODO: Get should be the default method
                 if "get" in data:
-                    method = "get"
+                    method = "get"  # default method
                 elif "post" in data:
                     method = "post"
                 elif "put" in data:
                     method = "put"
+                else:  # Default
+                    method = "get"
 
                 endpoint_parser = FerryParser.create_subparser(
                     endpoint,

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -17,11 +17,11 @@ try:
     from ferry_cli.helpers.api import FerryAPI
     from ferry_cli.helpers.auth import (
         Auth,
-        DebugLevel,
         get_auth_args,
         set_auth_from_args,
         get_auth_parser,
     )
+    from ferry_cli.helpers.debug_level import DebugLevel
     from ferry_cli.helpers.ferry_parser import FerryParser
     from ferry_cli.helpers.supported_workflows import SUPPORTED_WORKFLOWS
     from ferry_cli.safeguards.dcs import SafeguardsDCS
@@ -31,11 +31,11 @@ except ImportError:
     from helpers.api import FerryAPI  # type: ignore
     from helpers.auth import (  # type: ignore
         Auth,
-        DebugLevel,
         get_auth_args,
         set_auth_from_args,
         get_auth_parser,
     )
+    from helpers.debug_level import DebugLevel  # type: ignore
     from helpers.ferry_parser import FerryParser  # type: ignore
     from helpers.supported_workflows import SUPPORTED_WORKFLOWS  # type: ignore
     from safeguards.dcs import SafeguardsDCS  # type: ignore

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -9,8 +9,9 @@ import textwrap
 from typing import Any, Dict, Optional, List, Type
 from urllib.parse import urlsplit, urlunsplit, SplitResult
 
-import validators  # pylint: disable=import-error
+import validators
 
+# TODO: CLean up these imports
 # pylint: disable=unused-import
 try:
     # Try package import
@@ -154,6 +155,17 @@ class FerryCLI:
 
         return parser
 
+    def setup_FerryAPI(self: "FerryCLI", debug_level: DebugLevel = DebugLevel.NORMAL, dryrun=False, update=False) -> None:  # type: ignore # pylint: disable=invalid-name
+        self.ferry_api = FerryAPI(
+            base_url=self.base_url,
+            authorizer=self.authorizer,
+            debug_level=debug_level,
+            dryrun=dryrun,
+        )
+        if update:
+            self.ferry_api.get_latest_swagger_file()
+        self.endpoints = self.generate_endpoints()
+
     def list_available_endpoints_action(self: "FerryCLI"):  # type: ignore
         endpoints = self.endpoints
 
@@ -291,11 +303,18 @@ class FerryCLI:
             params_args, _ = subparser.parse_known_args(params)
             return self.ferry_api.call_endpoint(endpoint, params=vars(params_args))  # type: ignore
 
-    def generate_endpoints(self: "FerryCLI") -> Dict[str, FerryParser]:
+    def generate_endpoints(
+        self: "FerryCLI", debug_level: DebugLevel = DebugLevel.NORMAL
+    ) -> Dict[str, FerryParser]:
         endpoints = {}
-        # TODO: Use get_configfile_dir here
-        with open(f"{CONFIG_DIR}/swagger.json", "r") as json_file:
+        if not self.ferry_api:
+            self.ferry_api = FerryAPI(
+                base_url=self.base_url,
+                authorizer=self.authorizer,
+                debug_level=debug_level,
+            )
 
+        with open(self.ferry_api.swagger_file, "r") as json_file:
             api_data = json.load(json_file)
             for path, data in api_data["paths"].items():
                 endpoint = path.replace("/", "")
@@ -624,6 +643,9 @@ def normalize_endpoint(endpoints: Dict[str, Any], raw: str) -> str:
     return next((ep for ep in endpoints if ep.lower() == normalized.lower()), raw)
 
 
+# TODO: FerryAPI should be the one place that knows about the swagger file. Anything that needs that swagger file should call on the FerryAPI class to either provide or generate the file.
+# The two places that use it are 1) below, when the --update flag is used, and 2) in FerryCLI.generate_endpoints.  The latter should look to see if the FerryAPI class has been instantiated and stored locally, and if not, do that.  Then use FerryAPI.get_latest_swagger_file to get the swagger file.  Perhaps the latter should return a Path to the file.
+
 # pylint: disable=too-many-branches
 def main() -> None:
     _config_path = config.get_configfile_path()
@@ -683,12 +705,47 @@ def main() -> None:
                 if auth_args.debug_level != DebugLevel.QUIET:
                     print("No more arguments provided. Exiting.")
                 sys.exit(0)
+        ferry_cli.setup_FerryAPI(
+            debug_level=auth_args.debug_level,
+            dryrun=auth_args.dryrun,
+            update=auth_args.update,
+        )
+
+        # TODO: Order of operations now:
+        # 1. Make sure we have swagger file
+        # 1a. If we don't have any other args, we know it's a malformed call. Exit.  I don't like this.
+        # 2. Generate endpoints
+        # 3. Run call.
+
+        # TODO: Should be:
+        # 1. Instantiate API -- DONE
+        # . Maybe instantiating API should include update or not - to force update or not. -- DONE
+        # . Make sure we have swagger file inside this instantiation (ferry_cli.setup_api() or something like that?). Generate endpoints should be here too. -- DONE
+        # 3. Check for other args. -- DONE
+        # 4. Run call -- DONE
+
+        # if auth_args.update or not os.path.exists(f"{CONFIG_DIR}/swagger.json"):
+        #     if auth_args.debug_level != DebugLevel.QUIET:
+        #         print("Fetching latest swagger file...")
+        #     ferry_cli.ferry_api = FerryAPI(
+        #         ferry_cli.base_url,
+        #         ferry_cli.authorizer,
+        #         auth_args.debug_level,
+        #     )
+        #     ferry_cli.ferry_api.get_latest_swagger_file()
+        #     if auth_args.debug_level != DebugLevel.QUIET:
+        #         print("Successfully stored latest swagger file.\n")
+        #     if not other_args:
+        #         if auth_args.debug_level != DebugLevel.QUIET:
+        #             print("No more arguments provided. Exiting.")
+        #         sys.exit(0)
 
         if not other_args:
             ferry_cli.get_arg_parser().print_help()
             sys.exit(1)
 
-        ferry_cli.endpoints = ferry_cli.generate_endpoints()
+            # TODO: This should be done before we do anything!
+        # ferry_cli.endpoints = ferry_cli.generate_endpoints()
         ferry_cli.run(
             auth_args.debug_level,
             auth_args.dryrun,

--- a/src/ferry_cli/ferry_cli.py
+++ b/src/ferry_cli/ferry_cli.py
@@ -164,6 +164,8 @@ class FerryCLI:
         )
         if update:
             self.ferry_api.get_latest_swagger_file()
+        if dryrun:
+            return
         self.endpoints = self.generate_endpoints()
 
     def list_available_endpoints_action(self: "FerryCLI"):  # type: ignore
@@ -292,10 +294,17 @@ class FerryCLI:
             print(subparser.format_help())
             print()
 
-    def execute_endpoint(self: "FerryCLI", endpoint: str, params: List[str]) -> Any:
+    def execute_endpoint(
+        self: "FerryCLI", endpoint: str, params: List[str], dryrun: bool = False
+    ) -> Any:
         try:
             subparser = self.endpoints[endpoint]
         except KeyError:
+            if dryrun:
+                print(
+                    f"Could not find endpoint '{endpoint}' for FERRY server {self.base_url}."
+                )
+                return self.ferry_api.call_endpoint(endpoint)  # type: ignore
             raise ValueError(  # pylint: disable=raise-missing-from
                 f"Error: '{endpoint}' is not a valid endpoint. Run 'ferry -l' for a full list of available endpoints."
             )
@@ -388,7 +397,7 @@ class FerryCLI:
             ep = normalize_endpoint(self.endpoints, args.endpoint)
             self.safeguards.verify(ep)
             try:
-                json_result = self.execute_endpoint(ep, endpoint_args)
+                json_result = self.execute_endpoint(ep, endpoint_args, dryrun)
             except Exception as e:
                 raise Exception(f"{e}")
             if not dryrun:
@@ -744,8 +753,6 @@ def main() -> None:
             ferry_cli.get_arg_parser().print_help()
             sys.exit(1)
 
-            # TODO: This should be done before we do anything!
-        # ferry_cli.endpoints = ferry_cli.generate_endpoints()
         ferry_cli.run(
             auth_args.debug_level,
             auth_args.dryrun,

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -1,6 +1,5 @@
 import json
 import pathlib
-import sys
 from typing import Any, Dict, Optional
 import tempfile
 
@@ -75,10 +74,7 @@ class FerryAPI:
         _session = requests.Session()
         session = self.authorizer(_session)  # Handles auth for session
 
-        if extra:
-            for attribute_name, attribute_value in extra:
-                if attribute_name not in params:
-                    params[attribute_name] = attribute_value
+        merged_params = {**extra, **params}
 
         if method.lower() not in self.SUPPORTED_METHODS:
             raise ValueError(f"Unsupported HTTP method {method.lower()}.")
@@ -88,7 +84,7 @@ class FerryAPI:
             method=method.upper(),
             url=f"{self.base_url}{endpoint}",
             headers=headers,
-            params=params,
+            params=merged_params,
         )
 
         if debug:
@@ -116,16 +112,15 @@ class FerryAPI:
 
         response = self.call_endpoint(self.swagger_endpoint)
         if not response:
-            print("Failed to fetch swagger.json file")
-            sys.exit(1)
+            raise RuntimeError("Failed to fetch swagger.json file")
 
         self.swagger_file = self._set_swagger_file()
 
         try:
             self.swagger_file.parent.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
+        except Exception:
             print(f"Could not create dir {self.swagger_file.parent}")
-            raise e
+            raise
 
         with open(self.swagger_file, "w") as file:
             file.write(json.dumps(response, indent=4))

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -44,8 +44,6 @@ class FerryAPI:
         # TODO: Issue is if we use an integration test, or some bad server, it overwrites this swagger file. Maybe swagger file should contain some hash of server?
         self.swagger_file: pathlib.Path = self._set_swagger_file()
 
-        # TODO: Issue is if we use an integration test, or some bad server, it overwrites this swagger file. Maybe swagger file should contain some hash of server?
-
         if not self.swagger_file.exists():
             self.get_latest_swagger_file()
 
@@ -126,15 +124,12 @@ class FerryAPI:
 
         try:
             self.swagger_file.parent.mkdir(parents=True, exist_ok=True)
-        except BaseException as e:
+        except Exception as e:
             print(f"Could not create dir {self.swagger_file.parent}")
             raise e
 
         with open(self.swagger_file, "w") as file:
             file.write(json.dumps(response, indent=4))
-
-        if self.debug_level != DebugLevel.QUIET:
-            print("Successfully stored latest swagger file.\n")
 
         return
 

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -2,15 +2,16 @@ import json
 import pathlib
 import sys
 from typing import Any, Dict, Optional
+import tempfile
 
 import requests  # pylint: disable=import-error
 
 try:
     from ferry_cli.helpers.auth import Auth, DebugLevel
-    from ferry_cli.config import CONFIG_DIR
+    from ferry_cli.config.config import get_configfile_dir
 except ImportError:
     from helpers.auth import Auth, DebugLevel  # type: ignore
-    from config import CONFIG_DIR  # type: ignore
+    from config.config import get_configfile_dir  # type: ignore
 
 
 # pylint: disable=unused-argument,pointless-statement,too-many-arguments
@@ -40,6 +41,13 @@ class FerryAPI:
         self.swagger_endpoint = (
             swagger_endpoint if swagger_endpoint else self.SWAGGER_JSON_ENDPOINT_DEFAULT
         )
+        # TODO: Issue is if we use an integration test, or some bad server, it overwrites this swagger file. Maybe swagger file should contain some hash of server?
+        self.swagger_file: pathlib.Path = self._set_swagger_file()
+
+        # TODO: Issue is if we use an integration test, or some bad server, it overwrites this swagger file. Maybe swagger file should contain some hash of server?
+
+        if not self.swagger_file.exists():
+            self.get_latest_swagger_file()
 
     # pylint: disable=dangerous-default-value,too-many-arguments
     def call_endpoint(
@@ -114,13 +122,29 @@ class FerryAPI:
             print("Failed to fetch swagger.json file")
             sys.exit(1)
 
-        swagger_file = pathlib.Path(CONFIG_DIR) / "swagger.json"
+        self.swagger_file = self._set_swagger_file()
 
         try:
-            swagger_file.parent.mkdir(parents=True, exist_ok=True)
-        except Exception as e:
-            print(f"Could not create dir {swagger_file.parent}: {e}")
-            raise
+            self.swagger_file.parent.mkdir(parents=True, exist_ok=True)
+        except BaseException as e:
+            print(f"Could not create dir {self.swagger_file.parent}")
+            raise e
 
-        with open(swagger_file, "w") as file:
+        with open(self.swagger_file, "w") as file:
             file.write(json.dumps(response, indent=4))
+
+        if self.debug_level != DebugLevel.QUIET:
+            print("Successfully stored latest swagger file.\n")
+
+        return
+
+    # TODO: Unit test
+    def _set_swagger_file(self: "FerryAPI") -> pathlib.Path:
+        _config_dir = get_configfile_dir()
+        config_dir = (
+            _config_dir
+            if _config_dir is not None
+            else pathlib.Path(tempfile.gettempdir())
+        )
+        self.swagger_file = config_dir / "swagger.json"
+        return self.swagger_file

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -18,6 +18,8 @@ except ImportError:
 # pylint: disable=unused-argument,pointless-statement,too-many-arguments
 class FerryAPI:
     SWAGGER_JSON_ENDPOINT_DEFAULT = "swagger/swagger.json"
+    SUPPORTED_METHODS = set(("get", "post", "put"))
+
     # pylint: disable=too-many-arguments
     def __init__(
         self: "FerryAPI",
@@ -76,36 +78,28 @@ class FerryAPI:
             for attribute_name, attribute_value in extra:
                 if attribute_name not in params:
                     params[attribute_name] = attribute_value
-        # I believe they are all actually "GET" calls
-        # TODO: Just pass this to session.request, rather than this if/elif mess
-        try:
-            if method.lower() == "get":
-                response = session.get(
-                    f"{self.base_url}{endpoint}", headers=headers, params=params
-                )
-            elif method.lower() == "post":
-                response = session.post(
-                    f"{self.base_url}{endpoint}", params=params, headers=headers
-                )
-            elif method.lower() == "put":
-                response = session.put(
-                    f"{self.base_url}{endpoint}", params=params, headers=headers
-                )
-            else:
-                raise ValueError("Unsupported HTTP method.")
-            if debug:
-                print(f"\nCalled Endpoint: {response.request.url}")
-            if not response.ok:
-                raise RuntimeError(
-                    f" *** API Failure: Status code {response.status_code} returned from endpoint /{endpoint}"
-                )
-            output = response.json()
 
-            output["request_url"] = response.request.url
-            return output
-        except Exception as e:
-            # How do we want to handle errors?
-            raise e
+        if method.lower() not in self.SUPPORTED_METHODS:
+            raise ValueError(f"Unsupported HTTP method {method.lower()}.")
+
+        # Send our request
+        response = session.request(
+            method=method.upper(),
+            url=f"{self.base_url}{endpoint}",
+            headers=headers,
+            params=params,
+        )
+
+        if debug:
+            print(f"\nCalled Endpoint: {response.request.url}")
+        if not response.ok:
+            raise RuntimeError(
+                f" *** API Failure: Status code {response.status_code} returned from endpoint /{endpoint}"
+            )
+        output = response.json()
+
+        output["request_url"] = response.request.url
+        return output
 
     def get_latest_swagger_file(self: "FerryAPI") -> None:
         """

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import pathlib
 import sys
@@ -41,7 +42,6 @@ class FerryAPI:
         self.swagger_endpoint = (
             swagger_endpoint if swagger_endpoint else self.SWAGGER_JSON_ENDPOINT_DEFAULT
         )
-        # TODO: Issue is if we use an integration test, or some bad server, it overwrites this swagger file. Maybe swagger file should contain some hash of server?
         self.swagger_file: pathlib.Path = self._set_swagger_file()
 
         if not self.swagger_file.exists():
@@ -77,6 +77,7 @@ class FerryAPI:
                 if attribute_name not in params:
                     params[attribute_name] = attribute_value
         # I believe they are all actually "GET" calls
+        # TODO: Just pass this to session.request, rather than this if/elif mess
         try:
             if method.lower() == "get":
                 response = session.get(
@@ -106,10 +107,13 @@ class FerryAPI:
             # How do we want to handle errors?
             raise e
 
-    # TODO: integration test  # pylint: disable=fixme
     def get_latest_swagger_file(self: "FerryAPI") -> None:
         """
-        Gets the latest swagger file from FERRY and saves it in config.CONFIG_DIR/swagger.json
+        Gets the latest swagger file from FERRY and saves it in either:
+        1. Directory returned by config.get_configfile_dir()
+        2. Directory returned by tempfile.gettempdir()
+
+        The filename is computed using the base_url and swagger_endpoint of the FerryAPI instance.
         """
         if self.dryrun:
             print("Dryrun: skipping swagger.json fetching")
@@ -133,13 +137,30 @@ class FerryAPI:
 
         return
 
-    # TODO: Unit test
     def _set_swagger_file(self: "FerryAPI") -> pathlib.Path:
+        """
+        Returns a pathlib.Path where the swagger.json file should be saved.  In
+        order of precedence, will return a pathlib.Path whose parent is:
+        1. Directory returned by config.get_configfile_dir()
+        2. Directory returned by tempfile.gettempdir()
+
+        The filename within that directory is the value returned by FerryAPI._swagger_filename
+        """
         _config_dir = get_configfile_dir()
         config_dir = (
             _config_dir
             if _config_dir is not None
             else pathlib.Path(tempfile.gettempdir())
         )
-        self.swagger_file = config_dir / "swagger.json"
+
+        self.swagger_file = config_dir / self._swagger_filename()
         return self.swagger_file
+
+    def _swagger_filename(self: "FerryAPI") -> str:
+        """
+        Generate hash of endpoint including base_url
+        """
+        hasher = hashlib.sha256()
+        hasher.update(f"{self.base_url}/{self.swagger_endpoint}".encode("utf-8"))
+        suffix = hasher.hexdigest()[:16]
+        return f"swagger_{suffix}.json"

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -8,10 +8,12 @@ import tempfile
 import requests  # pylint: disable=import-error
 
 try:
-    from ferry_cli.helpers.auth import Auth, DebugLevel
+    from ferry_cli.helpers.auth import Auth
+    from ferry_cli.helpers.debug_level import DebugLevel
     from ferry_cli.config.config import get_configfile_dir
 except ImportError:
-    from helpers.auth import Auth, DebugLevel  # type: ignore
+    from helpers.auth import Auth  # type: ignore
+    from helpers.debug_level import DebugLevel  # type: ignore
     from config.config import get_configfile_dir  # type: ignore
 
 

--- a/src/ferry_cli/helpers/api.py
+++ b/src/ferry_cli/helpers/api.py
@@ -1,4 +1,3 @@
-import hashlib
 import json
 import pathlib
 import sys
@@ -10,11 +9,11 @@ import requests  # pylint: disable=import-error
 try:
     from ferry_cli.helpers.auth import Auth
     from ferry_cli.helpers.debug_level import DebugLevel
-    from ferry_cli.config.config import get_configfile_dir
+    from ferry_cli.config.config import get_configfile_dir, swagger_filename
 except ImportError:
     from helpers.auth import Auth  # type: ignore
     from helpers.debug_level import DebugLevel  # type: ignore
-    from config.config import get_configfile_dir  # type: ignore
+    from config.config import get_configfile_dir, swagger_filename  # type: ignore
 
 
 # pylint: disable=unused-argument,pointless-statement,too-many-arguments
@@ -156,7 +155,4 @@ class FerryAPI:
         """
         Generate hash of endpoint including base_url
         """
-        hasher = hashlib.sha256()
-        hasher.update(f"{self.base_url}/{self.swagger_endpoint}".encode("utf-8"))
-        suffix = hasher.hexdigest()[:16]
-        return f"swagger_{suffix}.json"
+        return swagger_filename(self.base_url, self.swagger_endpoint)

--- a/src/ferry_cli/helpers/auth.py
+++ b/src/ferry_cli/helpers/auth.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from argparse import Namespace
-import enum
 from os import geteuid
 import os.path
 from typing import List, Optional, Tuple
@@ -9,9 +8,11 @@ from typing import List, Optional, Tuple
 import requests
 
 try:
+    from ferry_cli.helpers.debug_level import DebugLevel
     from ferry_cli.helpers.ferry_parser import FerryParser
     from ferry_cli.version import request_project_info
 except ImportError:
+    from helpers.debug_level import DebugLevel  # type: ignore
     from helpers.ferry_parser import FerryParser  # type: ignore
     from version import request_project_info  # type: ignore
 
@@ -249,9 +250,3 @@ def get_auth_args() -> Tuple[Namespace, List[str]]:
     parser = get_auth_parser()
     auth_args, other_args = parser.parse_known_args()
     return auth_args, other_args
-
-
-class DebugLevel(enum.Enum):
-    QUIET = 0
-    NORMAL = 1
-    DEBUG = 2

--- a/src/ferry_cli/helpers/auth.py
+++ b/src/ferry_cli/helpers/auth.py
@@ -89,7 +89,7 @@ def get_default_cert_path(debug: bool = False) -> str:
 class Auth(ABC):
     """This is the base class on which all Auth classes should build"""
 
-    def __call__(self: "Auth", s: requests.Session) -> requests.Session:
+    def __call__(self: "Auth", _: requests.Session) -> requests.Session:
         raise NotImplementedError(
             "Must use a subclass of Auth with __call__ method defined"
         )

--- a/src/ferry_cli/helpers/debug_level.py
+++ b/src/ferry_cli/helpers/debug_level.py
@@ -1,0 +1,9 @@
+from enum import Enum
+
+
+class DebugLevel(Enum):
+    """Enumerator that allows callers to choose a debug level for their operations"""
+
+    QUIET = 0
+    NORMAL = 1
+    DEBUG = 2

--- a/src/ferry_cli/helpers/supported_workflows/CloneResource.py
+++ b/src/ferry_cli/helpers/supported_workflows/CloneResource.py
@@ -4,11 +4,11 @@ from typing import Any, Dict
 
 try:
     from ferry_cli.helpers.api import FerryAPI
-    from ferry_cli.helpers.auth import DebugLevel
+    from ferry_cli.helpers.debug_level import DebugLevel
     from ferry_cli.helpers.workflows import Workflow
 except ImportError:
     from helpers.api import FerryAPI  # type: ignore
-    from helpers.auth import DebugLevel  # type: ignore
+    from helpers.debug_level import DebugLevel  # type: ignore
     from helpers.workflows import Workflow  # type: ignore
 
 

--- a/src/ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py
+++ b/src/ferry_cli/helpers/supported_workflows/GetFilteredGroupInfo.py
@@ -2,10 +2,10 @@
 from typing import Any, Dict, List
 
 try:
-    from ferry_cli.helpers.auth import DebugLevel
+    from ferry_cli.helpers.debug_level import DebugLevel
     from ferry_cli.helpers.workflows import Workflow
 except ImportError:
-    from helpers.auth import DebugLevel  # type: ignore
+    from helpers.debug_level import DebugLevel  # type: ignore
     from helpers.workflows import Workflow  # type: ignore
 
 

--- a/src/ferry_cli/helpers/supported_workflows/NewCapabilitySet.py
+++ b/src/ferry_cli/helpers/supported_workflows/NewCapabilitySet.py
@@ -3,11 +3,11 @@ from typing import Any, List
 
 try:
     from ferry_cli.helpers.api import FerryAPI
-    from ferry_cli.helpers.auth import DebugLevel
+    from ferry_cli.helpers.debug_level import DebugLevel
     from ferry_cli.helpers.workflows import Workflow
 except ImportError:
     from helpers.api import FerryAPI  # type: ignore
-    from helpers.auth import DebugLevel  # type: ignore
+    from helpers.debug_level import DebugLevel  # type: ignore
     from helpers.workflows import Workflow  # type: ignore
 
 

--- a/src/ferry_cli/version.py
+++ b/src/ferry_cli/version.py
@@ -2,18 +2,17 @@ import argparse
 import configparser
 from importlib.metadata import version
 import json
-import os
 import sys
 from typing import Optional
 
 try:
-    from ferry_cli.config.config import get_configfile_path
-    from ferry_cli.helpers.api import FerryAPI
-    from ferry_cli.helpers.auth import Auth
+    from ferry_cli.config.config import (
+        get_configfile_path,
+        get_configfile_dir,
+        swagger_filename,
+    )
 except ImportError:
-    from config.config import get_configfile_path  # type: ignore
-    from helpers.api import FerryAPI  # type: ignore
-    from helpers.auth import Auth  # type: ignore
+    from config.config import get_configfile_path, get_configfile_dir, swagger_filename  # type: ignore
 
 __title__ = "Ferry CLI"
 __swagger_file_title__ = "Ferry API"
@@ -34,10 +33,6 @@ def print_version(full: bool = False, short: bool = False) -> Optional[str]:
         return __version__
     print(f"{__title__} version {__version__}")
 
-    class fakeAuth(Auth):
-        def __call__(self):
-            pass
-
     try:
         config_path = get_configfile_path()
         assert config_path is not None
@@ -46,37 +41,35 @@ def print_version(full: bool = False, short: bool = False) -> Optional[str]:
         with open(config_path, "r") as f:
             configs.read_file(f)
 
-        _base_url = configs.get("api", "base_url", fallback=None)
-        if _base_url is None:
+        base_url = configs.get("api", "base_url", fallback="").strip(' "') or None
+        if base_url is None:
             raise ValueError(
                 f"api.base_url must be specified in the config file at {config_path}. "
                 "Please set that value and try again."
             )
-        base_url = _base_url.strip().strip('"')
-        _api = FerryAPI(
-            base_url=base_url,
-            authorizer=fakeAuth,
-            swagger_endpoint=configs.get(
-                "api", "swagger_file_endpoint", fallback=""
-            ).strip(' "')
-            or None,
+        swagger_endpoint = (
+            configs.get("api", "swagger_file_endpoint", fallback="").strip(' "') or None
         )
 
-        with open(_api.swagger_file, "r") as file:
+        config_dir = get_configfile_dir()
+        assert config_dir is not None
+
+        _swagger_filename_kwargs = {"base_url": base_url}
+        if swagger_endpoint:
+            _swagger_filename_kwargs.update({"swagger_endpoint": swagger_endpoint})
+        swagger_file = swagger_filename(**_swagger_filename_kwargs)
+
+        with open(swagger_file, "r") as file:
             json_file = json.load(file)
             file_version = json_file.get("info", {}).get("version", None)
         if file_version and full:
             print(f"Interfacing with {__swagger_file_title__} version {file_version}")
 
-    except Exception as e:
+    except Exception as e:  # pylint: disable=broad-except
         print(f"Error getting FERRY server version: {e}")
         sys.exit(1)
 
     sys.exit(0)
-
-    # TODO: Get config file, get base_url.  Feed that into FerryAPI to get swagger.json.  Use swagger json.  if any of this fails, just print error, return
-
-    sys.exit()
 
 
 def print_support_email() -> None:

--- a/src/ferry_cli/version.py
+++ b/src/ferry_cli/version.py
@@ -57,7 +57,7 @@ def print_version(full: bool = False, short: bool = False) -> Optional[str]:
         _swagger_filename_kwargs = {"base_url": base_url}
         if swagger_endpoint:
             _swagger_filename_kwargs.update({"swagger_endpoint": swagger_endpoint})
-        swagger_file = swagger_filename(**_swagger_filename_kwargs)
+        swagger_file = config_dir / swagger_filename(**_swagger_filename_kwargs)
 
         with open(swagger_file, "r") as file:
             json_file = json.load(file)
@@ -67,7 +67,6 @@ def print_version(full: bool = False, short: bool = False) -> Optional[str]:
 
     except Exception as e:  # pylint: disable=broad-except
         print(f"Error getting FERRY server version: {e}")
-        sys.exit(1)
 
     sys.exit(0)
 

--- a/src/ferry_cli/version.py
+++ b/src/ferry_cli/version.py
@@ -1,4 +1,5 @@
 import argparse
+import configparser
 from importlib.metadata import version
 import json
 import os
@@ -6,9 +7,13 @@ import sys
 from typing import Optional
 
 try:
-    from ferry_cli.config import CONFIG_DIR
+    from ferry_cli.config.config import get_configfile_path
+    from ferry_cli.helpers.api import FerryAPI
+    from ferry_cli.helpers.auth import Auth
 except ImportError:
-    from config import CONFIG_DIR  # type: ignore
+    from config.config import get_configfile_path  # type: ignore
+    from helpers.api import FerryAPI  # type: ignore
+    from helpers.auth import Auth  # type: ignore
 
 __title__ = "Ferry CLI"
 __swagger_file_title__ = "Ferry API"
@@ -25,16 +30,52 @@ def get_summary() -> str:
 
 
 def print_version(full: bool = False, short: bool = False) -> Optional[str]:
-    file_version = None
-    if os.path.exists(f"{CONFIG_DIR}/swagger.json"):
-        with open(f"{CONFIG_DIR}/swagger.json", "r") as file:
-            json_file = json.load(file)
-            file_version = json_file.get("info", {}).get("version", None)
     if short:
         return __version__
     print(f"{__title__} version {__version__}")
-    if file_version and full:
-        print(f"Interfacing with {__swagger_file_title__} version {file_version}")
+
+    class fakeAuth(Auth):
+        def __call__(self):
+            pass
+
+    try:
+        config_path = get_configfile_path()
+        assert config_path is not None
+
+        configs = configparser.ConfigParser()
+        with open(config_path, "r") as f:
+            configs.read_file(f)
+
+        _base_url = configs.get("api", "base_url", fallback=None)
+        if _base_url is None:
+            raise ValueError(
+                f"api.base_url must be specified in the config file at {config_path}. "
+                "Please set that value and try again."
+            )
+        base_url = _base_url.strip().strip('"')
+        _api = FerryAPI(
+            base_url=base_url,
+            authorizer=fakeAuth,
+            swagger_endpoint=configs.get(
+                "api", "swagger_file_endpoint", fallback=""
+            ).strip(' "')
+            or None,
+        )
+
+        with open(_api.swagger_file, "r") as file:
+            json_file = json.load(file)
+            file_version = json_file.get("info", {}).get("version", None)
+        if file_version and full:
+            print(f"Interfacing with {__swagger_file_title__} version {file_version}")
+
+    except Exception as e:
+        print(f"Error getting FERRY server version: {e}")
+        sys.exit(1)
+
+    sys.exit(0)
+
+    # TODO: Get config file, get base_url.  Feed that into FerryAPI to get swagger.json.  Use swagger json.  if any of this fails, just print error, return
+
     sys.exit()
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,17 @@
 import os
 
+from requests import Session
 import pytest
+
+from ferry_cli.helpers.auth import Auth
+
+
+class fakeAuth(Auth):
+    def __init__(self):
+        pass
+
+    def __call__(self, s: Session) -> Session:
+        return s
 
 
 @pytest.fixture

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,10 +1,10 @@
-from functools import partial
-import pytest
+import json
+import os
 import subprocess
 import time
 from typing import Dict, Any
-import json
-import os
+
+import pytest
 
 from ferry_cli.helpers.api import FerryAPI, tempfile
 from ferry_cli.helpers.auth import AuthToken

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,4 @@
+from functools import partial
 import pytest
 import subprocess
 import time
@@ -5,8 +6,9 @@ from typing import Dict, Any
 import json
 import os
 
-from ferry_cli.helpers.api import FerryAPI
+from ferry_cli.helpers.api import FerryAPI, tempfile
 from ferry_cli.helpers.auth import AuthToken
+from tests.conftest import fakeAuth
 
 TokenGetCommand = "htgettoken"
 tokenDestroyCommand = "htdestroytoken"
@@ -96,6 +98,15 @@ def sendToEndpoint(get_token):
     return _sendToEndpoint
 
 
+@pytest.fixture
+def reload_import_tempfile(monkeypatch):
+    from importlib import reload
+
+    yield
+    monkeypatch.undo()
+    reload(tempfile)
+
+
 # --- tests below ----
 
 
@@ -115,6 +126,78 @@ def test_getAllGroups(getEncodedToken, sendToEndpoint):
     result = sendToEndpoint(getEncodedToken, "getAllGroups")
     assert (result["ferry_status"]) == "success"
     assert result["ferry_output"]  # Make sure we got non-empty result
+
+
+class TestGetLatestSwaggerFile:
+    @classmethod
+    def setup_class(cls):
+        cls.auth = fakeAuth()
+        cls.base_url = "https://test.example.com"
+
+    @pytest.mark.unit
+    def test_dryrun(self, monkeypatch, tmp_path, capsys):
+        tmp = tmp_path
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp))
+        api = FerryAPI(base_url=self.base_url, authorizer=self.auth, dryrun=True)
+        api.get_latest_swagger_file()
+        captured = capsys.readouterr()
+        assert "Dryrun: skipping swagger.json fetching" in captured.out
+        assert not api.swagger_file.exists()
+
+    @pytest.mark.integration
+    def test_regular(self, monkeypatch, tmp_path, capsys, get_token):
+        tmp = tmp_path
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp))
+        api = FerryAPI(
+            base_url=f"{FERRY_DEV_SERVER}:{FERRY_DEV_PORT}/", authorizer=AuthToken()
+        )
+        api.get_latest_swagger_file()
+        captured = capsys.readouterr()
+        assert api.swagger_file.exists()
+
+
+class TestSetSwaggerFile:
+    @classmethod
+    def setup_class(cls):
+        _auth = fakeAuth()
+        cls.api = FerryAPI(
+            base_url="https://test.example.com", authorizer=_auth, dryrun=True
+        )
+
+    @pytest.mark.unit
+    def test_set_swagger_file_configdir(self, monkeypatch, tmp_path):
+        tmp = tmp_path
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
+
+        filename = self.api._swagger_filename()
+        assert (
+            self.api._set_swagger_file().resolve()
+            == (tmp / "ferry_cli" / filename).resolve()
+        )
+
+    @pytest.mark.unit
+    def test_set_swagger_file_tmpdir(
+        self, monkeypatch, tmp_path, reload_import_tempfile
+    ):
+        from importlib import reload
+
+        tmp = tmp_path
+        monkeypatch.setenv("TMPDIR", str(tmp))
+        monkeypatch.delenv("HOME")
+        monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+
+        reload(tempfile)
+
+        filename = self.api._swagger_filename()
+        assert self.api._set_swagger_file().resolve() == tmp / filename
+
+
+@pytest.mark.unit
+def test_swagger_filename():
+    _auth = fakeAuth()
+    api = FerryAPI(base_url="https://test.example.com", authorizer=_auth, dryrun=True)
+    # Hash should be created from "https://test.example.com/swagger/swagger.json"
+    assert api._swagger_filename() == f"swagger_9da5f7c34792d7ef.json"
 
 
 # --- test helper functions

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -63,22 +63,20 @@ def get_write_out_configfile_test_params():
 
 
 @pytest.mark.unit
-def test_get_configfile_xdg_config_home_(
+def test_get_configfile_dir_xdg_config_home_(
     stash_xdg_config_home, create_config_file_dummy, tmp_path, monkeypatch
 ):
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
-    assert not config._get_configfile_path_xdg_config_home()
+    assert not config._get_configfile_dir_xdg_config_home()
     env_path = tmp_path
     monkeypatch.setenv("XDG_CONFIG_HOME", env_path)
     create_config_file_dummy(env_path, "ferry_cli")
 
-    assert config._get_configfile_path_xdg_config_home() == pathlib.Path(
-        f"{env_path}/ferry_cli/config.ini"
-    )
+    assert config._get_configfile_dir_xdg_config_home() == pathlib.Path(f"{env_path}")
 
 
 @pytest.mark.unit
-def test_get_configfile_home(
+def test_get_configfile_dir_home(
     stash_home, create_config_file_dummy, tmp_path, monkeypatch
 ):
     monkeypatch.delenv("HOME", raising=False)
@@ -86,9 +84,7 @@ def test_get_configfile_home(
     create_config_file_dummy(env_path, ".config", "ferry_cli")
     monkeypatch.setenv("HOME", env_path)
 
-    assert config._get_configfile_path_home() == pathlib.Path(
-        f"{env_path}/.config/ferry_cli/config.ini"
-    )
+    assert config._get_configfile_dir_home() == pathlib.Path(f"{env_path}/.config")
 
 
 class _expectedPathRoot(enum.Enum):
@@ -97,26 +93,71 @@ class _expectedPathRoot(enum.Enum):
     NOT_FOUND = 3
 
 
-configfile_test_param = namedtuple(
-    "configfile_test_param",
+configfile_dir_test_param = namedtuple(
+    "configfile_dir_test_param",
     [
-        "xdg_config_home_path",
-        "home_config_path",
+        "xdg_config_home_dir",
+        "home_config_dir",
         "expected",
     ],
 )
 
-get_configfile_params_for_test = [
-    configfile_test_param(True, True, _expectedPathRoot.XDG_CONFIG_HOME),
-    configfile_test_param(True, False, _expectedPathRoot.XDG_CONFIG_HOME),
-    configfile_test_param(False, True, _expectedPathRoot.HOME),
-    configfile_test_param(False, False, _expectedPathRoot.NOT_FOUND),
+get_configfile_params_for_dir_test = [
+    configfile_dir_test_param(True, True, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_dir_test_param(True, False, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_dir_test_param(False, True, _expectedPathRoot.HOME),
+    configfile_dir_test_param(False, False, _expectedPathRoot.NOT_FOUND),
 ]
 
 
 @pytest.mark.parametrize(
     "param_val",
-    get_configfile_params_for_test,
+    get_configfile_params_for_dir_test,
+)
+@pytest.mark.unit
+def test_get_configfile_dir(
+    stash_xdg_config_home,
+    stash_home,
+    tmp_path,
+    monkeypatch,
+    param_val,
+):
+    monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
+    monkeypatch.delenv("HOME", raising=False)
+    xdg_path = tmp_path
+    home_path = tmp_path
+    if param_val.xdg_config_home_dir:
+        monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
+    if param_val.home_config_dir:
+        monkeypatch.setenv("HOME", home_path)
+
+    if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
+        expectedPath = xdg_path / "ferry_cli"
+        assert config.get_configfile_dir() == expectedPath
+    elif param_val.expected == _expectedPathRoot.HOME:
+        expectedPath = home_path / ".config" / "ferry_cli"
+        assert config.get_configfile_dir() == expectedPath
+    else:
+        assert not config.get_configfile_dir()
+
+
+configfile_path_test_param = namedtuple(
+    "configfile_path_test_param",
+    [
+        "xdg_config_home_dir",
+        "expected",
+    ],
+)
+
+get_configfile_params_for_path_test = [
+    configfile_path_test_param(True, _expectedPathRoot.XDG_CONFIG_HOME),
+    configfile_path_test_param(False, _expectedPathRoot.NOT_FOUND),
+]
+
+
+@pytest.mark.parametrize(
+    "param_val",
+    get_configfile_params_for_path_test,
 )
 @pytest.mark.unit
 def test_get_configfile_path(
@@ -129,17 +170,11 @@ def test_get_configfile_path(
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     monkeypatch.delenv("HOME", raising=False)
     xdg_path = tmp_path
-    home_path = tmp_path
-    if param_val.xdg_config_home_path:
+    if param_val.xdg_config_home_dir:
         monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
-    if param_val.home_config_path:
-        monkeypatch.setenv("HOME", home_path)
 
     if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
         expectedPath = xdg_path / "ferry_cli" / "config.ini"
-        assert config.get_configfile_path() == expectedPath
-    elif param_val.expected == _expectedPathRoot.HOME:
-        expectedPath = home_path / ".config" / "ferry_cli" / "config.ini"
         assert config.get_configfile_path() == expectedPath
     else:
         assert not config.get_configfile_path()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -69,7 +69,7 @@ def test_get_configfile_dir_xdg_config_home_(
     monkeypatch.delenv("XDG_CONFIG_HOME", raising=False)
     assert not config._get_configfile_dir_xdg_config_home()
     env_path = tmp_path
-    monkeypatch.setenv("XDG_CONFIG_HOME", env_path)
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(env_path))
     create_config_file_dummy(env_path, "ferry_cli")
 
     assert config._get_configfile_dir_xdg_config_home() == pathlib.Path(f"{env_path}")
@@ -82,7 +82,7 @@ def test_get_configfile_dir_home(
     monkeypatch.delenv("HOME", raising=False)
     env_path = tmp_path
     create_config_file_dummy(env_path, ".config", "ferry_cli")
-    monkeypatch.setenv("HOME", env_path)
+    monkeypatch.setenv("HOME", str(env_path))
 
     assert config._get_configfile_dir_home() == pathlib.Path(f"{env_path}/.config")
 
@@ -127,9 +127,9 @@ def test_get_configfile_dir(
     xdg_path = tmp_path
     home_path = tmp_path
     if param_val.xdg_config_home_dir:
-        monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_path))
     if param_val.home_config_dir:
-        monkeypatch.setenv("HOME", home_path)
+        monkeypatch.setenv("HOME", str(home_path))
 
     if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
         expectedPath = xdg_path / "ferry_cli"
@@ -171,7 +171,7 @@ def test_get_configfile_path(
     monkeypatch.delenv("HOME", raising=False)
     xdg_path = tmp_path
     if param_val.xdg_config_home_dir:
-        monkeypatch.setenv("XDG_CONFIG_HOME", xdg_path)
+        monkeypatch.setenv("XDG_CONFIG_HOME", str(xdg_path))
 
     if param_val.expected == _expectedPathRoot.XDG_CONFIG_HOME:
         expectedPath = xdg_path / "ferry_cli" / "config.ini"

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,6 +47,8 @@ def install_mock_swagger_json_file(tmp_path, request):
         old_file = shutil.move(_api.swagger_file, tmp_path / "old_swagger.json")
     except FileNotFoundError:
         old_file = None
+        _api.swagger_file.parent.mkdir(parents=True, exist_ok=True)
+
     with open(_api.swagger_file, "w") as f:
         f.write(
             """

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import pytest
+import requests
 
 from ferry_cli.ferry_cli import (
     FerryCLI,
@@ -17,6 +18,9 @@ from ferry_cli.ferry_cli import (
 
 import ferry_cli.ferry_cli as _main
 import ferry_cli.config.config as _config
+import ferry_cli.helpers.api as api
+import ferry_cli.helpers.auth as auth
+from tests.conftest import fakeAuth
 
 
 @pytest.fixture
@@ -27,18 +31,23 @@ def get_ferry_cli_path():
 
 
 @pytest.fixture
-def install_mock_swagger_json_file(tmp_path):
+def install_mock_swagger_json_file(tmp_path, request):
+    # Note: Pass base_url in as parameter
     import os
     import shutil
 
-    root = pathlib.Path(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    configdir = root / "src" / "ferry_cli" / "config"
-    swagger_path = configdir / "swagger.json"
     try:
-        old_file = shutil.move(swagger_path, tmp_path / "old_swagger.json")
+        base_url = request.param
+    except AttributeError:
+        base_url = "https://example.com"
+
+    _api = api.FerryAPI(base_url=base_url, authorizer=fakeAuth(), dryrun=True)
+
+    try:
+        old_file = shutil.move(_api.swagger_file, tmp_path / "old_swagger.json")
     except FileNotFoundError:
         old_file = None
-    with open(swagger_path, "w") as f:
+    with open(_api.swagger_file, "w") as f:
         f.write(
             """
 {
@@ -75,9 +84,9 @@ def install_mock_swagger_json_file(tmp_path):
         )
 
     yield
-    os.unlink(swagger_path)
+    os.unlink(_api.swagger_file)
     if old_file is not None:
-        shutil.move(old_file, swagger_path)
+        shutil.move(old_file, _api.swagger_file)
 
 
 @pytest.fixture
@@ -198,7 +207,7 @@ def test_handle_show_configfile_envs_not_found(
         (
             ["-h", "--show-config-file", "-e", "getAllGroups"],
             "--show-config-file",
-        ),  # If we pass -h and --show-config-file, -h should win
+        ),  # If we pass -h and --show-config-file, -h should wi
         (
             ["--show-config-file"],
             "Configuration file",
@@ -421,10 +430,11 @@ dev_url = https://example.com:12345/
 
 
 @pytest.mark.parametrize(
-    "args, expected_out_url",
+    "install_mock_swagger_json_file, args, expected_out_url",
     [
-        ([], "https://example.com:12345/"),  # Get base_url from config
+        ("", [], "https://example.com:12345/"),  # Get base_url from config
         (
+            "https://override_example.com:54321/",
             ["--server", "https://override_example.com:54321/"],
             "https://override_example.com:54321/",
         ),  # Get base_url from override

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@ from ferry_cli.ferry_cli import (
     help_called,
     normalize_endpoint,
 )
+
 import ferry_cli.ferry_cli as _main
 import ferry_cli.config.config as _config
 
@@ -429,7 +430,7 @@ dev_url = https://example.com:12345/
         ),  # Get base_url from override
     ],
 )
-@pytest.mark.test
+@pytest.mark.integration
 def test_server_flag_main(
     tmp_path,
     monkeypatch,

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -6,7 +6,6 @@ import subprocess
 import sys
 
 import pytest
-import requests
 
 from ferry_cli.ferry_cli import (
     FerryCLI,
@@ -18,9 +17,6 @@ from ferry_cli.ferry_cli import (
 
 import ferry_cli.ferry_cli as _main
 import ferry_cli.config.config as _config
-import ferry_cli.helpers.api as api
-import ferry_cli.helpers.auth as auth
-from tests.conftest import fakeAuth
 
 
 @pytest.fixture
@@ -31,25 +27,24 @@ def get_ferry_cli_path():
 
 
 @pytest.fixture
-def install_mock_swagger_json_file(tmp_path, request):
+def install_mock_configs(monkeypatch, tmp_path, request):
     # Note: Pass base_url in as parameter
-    import os
-    import shutil
+
+    _fake_config_dir = tmp_path
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(_fake_config_dir.absolute()))
 
     try:
         base_url = request.param
     except AttributeError:
         base_url = "https://example.com"
 
-    _api = api.FerryAPI(base_url=base_url, authorizer=fakeAuth(), dryrun=True)
+    config_dir = _config.get_configfile_dir()
+    assert config_dir is not None
+    config_dir.mkdir(parents=True, exist_ok=True)
 
-    try:
-        old_file = shutil.move(_api.swagger_file, tmp_path / "old_swagger.json")
-    except FileNotFoundError:
-        old_file = None
-        _api.swagger_file.parent.mkdir(parents=True, exist_ok=True)
-
-    with open(_api.swagger_file, "w") as f:
+    # Fake swagger.json file
+    swagger_path = config_dir / _config.swagger_filename(base_url)
+    with open(swagger_path, "w") as f:
         f.write(
             """
 {
@@ -85,10 +80,16 @@ def install_mock_swagger_json_file(tmp_path, request):
                 """
         )
 
+        # fake config file
+    fake_config_text = """[api]
+base_url = https://example.com:12345/
+dev_url = https://example.com:12345/
+
+"""
+    # Fake config file
+    config_file = config_dir / "config.ini"
+    config_file.write_text(fake_config_text)
     yield
-    os.unlink(_api.swagger_file)
-    if old_file is not None:
-        shutil.move(old_file, _api.swagger_file)
 
 
 @pytest.fixture
@@ -115,11 +116,11 @@ def mock_write_config_file_with_user_values(monkeypatch):
 def write_and_set_fake_config_file(monkeypatch, tmp_path):
     # Fake config file
     p = tmp_path
+    monkeypatch.setenv("XDG_CONFIG_HOME", str(p.absolute()))
     config_dir = p / "ferry_cli"
-    config_dir.mkdir()
+    config_dir.mkdir(parents=True, exist_ok=True)
     config_file = config_dir / "config.ini"
     config_file.write_text("This is a fake config file")
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(p.absolute()))
     return config_file
 
 
@@ -209,7 +210,7 @@ def test_handle_show_configfile_envs_not_found(
         (
             ["-h", "--show-config-file", "-e", "getAllGroups"],
             "--show-config-file",
-        ),  # If we pass -h and --show-config-file, -h should wi
+        ),  # If we pass -h and --show-config-file, -h should win
         (
             ["--show-config-file"],
             "Configuration file",
@@ -222,7 +223,7 @@ def test_handle_show_configfile_envs_not_found(
 )
 @pytest.mark.unit
 def test_show_configfile_flag_with_other_args(
-    install_mock_swagger_json_file,
+    install_mock_configs,
     get_ferry_cli_path,
     write_and_set_fake_config_file,
     args,
@@ -432,7 +433,7 @@ dev_url = https://example.com:12345/
 
 
 @pytest.mark.parametrize(
-    "install_mock_swagger_json_file, args, expected_out_url",
+    "install_mock_configs, args, expected_out_url",
     [
         ("", [], "https://example.com:12345/"),  # Get base_url from config
         (
@@ -441,36 +442,21 @@ dev_url = https://example.com:12345/
             "https://override_example.com:54321/",
         ),  # Get base_url from override
     ],
+    indirect=["install_mock_configs"],
 )
 @pytest.mark.integration
 def test_server_flag_main(
-    tmp_path,
-    monkeypatch,
-    install_mock_swagger_json_file,
+    install_mock_configs,
     get_ferry_cli_path,
     args,
     expected_out_url,
 ):
     # Run ferry-cli with overridden base_url in dryrun mode to endpoint ping. Then see if we see the correct server in output
-    # Set up fake config
-    fake_config_text = """
-[api]
-base_url = https://example.com:12345/
-dev_url = https://example.com:12345/
-
-"""
-    # Fake config file
-    p = tmp_path
-    config_dir = p / "ferry_cli"
-    config_dir.mkdir()
-    config_file = config_dir / "config.ini"
-    config_file.write_text(fake_config_text)
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(p.absolute()))
 
     exe_args = [sys.executable, get_ferry_cli_path]
     exe_args.extend(args + ["--dryrun", "-e", "ping"])
 
-    proc = subprocess.run(exe_args, capture_output=True)
+    proc = subprocess.run(exe_args, capture_output=True, env=os.environ)
     assert f"Would call endpoint: {expected_out_url}ping with params" in str(
         proc.stdout
     )


### PR DESCRIPTION
This PR updates Ferry CLI’s swagger caching behavior so swagger.json is stored in a user-owned location (`$XDG_CONFIG_DIR/ferry-cli` when available, otherwise `$HOME/.config/ferry-cli`, else a temp directory) rather than alongside the installed source, addressing https://github.com/fermitools/Ferry-CLI/issues/113.

Changes:
- Add get_configfile_dir() and refactor config path helpers to separate “config dir” vs “config.ini path”. Also added a function that computes a per-server swagger filename
- Update FerryAPI to use the per-swagger filename and use it to store swagger file under the user config dir (or temp dir), fetching it when missing.

(Edited from Copilot-generated summary)

All unit and integration tests pass.

Closes #113